### PR TITLE
fix: modify build.gradle to fix unittest project errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,6 @@ android {
     namespace = "com.android.shelfLife"
     compileSdk = 34
 
-
     // Load the API key from local.properties
     val localProperties = Properties()
     val localPropertiesFile = rootProject.file("local.properties")
@@ -32,7 +31,11 @@ android {
             useSupportLibrary = true
         }
     }
-
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -48,11 +51,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
Edited build.gradle to fix the errors:
-updated jvmTarget and JavaVersion to v_11 to fix jvm target compile errors. 
-added testOptions to include AndroidResources to fix missing AndroidManifest.xml and other missing resources

closes issue 22