### PR TITLE
Integrate Camera and Add Navigation from Sign-In Screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,7 @@ dependencies {
     implementation(libs.camerax.camera2)
     implementation(libs.camerax.lifecycle)
     implementation(libs.camerax.view)
+    implementation(libs.guava)
 
 
     // Navigation

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,7 +122,11 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
 
 
-
+    //Barcode Scanner
+    implementation(libs.mlkit.barcode.scanning)
+    implementation(libs.camerax.camera2)
+    implementation(libs.camerax.lifecycle)
+    implementation(libs.camerax.view)
 
 
     // Navigation

--- a/app/src/androidTest/java/com/android/shelflife/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.android.shelflife
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -15,10 +13,10 @@ import org.junit.Assert.*
  */
 @RunWith(AndroidJUnit4::class)
 class ExampleInstrumentedTest {
-    @Test
-    fun useAppContext() {
-        // Context of the app under test.
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.android.shelflife", appContext.packageName)
-    }
+  @Test
+  fun useAppContext() {
+    // Context of the app under test.
+    val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+    assertEquals("com.android.shelflife", appContext.packageName)
+  }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.ShelfLife"
         tools:targetApi="31">
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.ShelfLife">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -1,72 +1,28 @@
 package com.android.shelfLife
 
-import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import com.android.shelfLife.ui.authentication.SignInScreen
 import com.android.shelfLife.ui.camera.BarcodeScannerScreen
+import com.android.shelfLife.ui.camera.CameraPermissionHandler
+import com.android.shelfLife.ui.camera.PermissionDeniedScreen
 import com.android.shelfLife.ui.navigation.NavigationActions
 import com.android.shelfLife.ui.navigation.Route
 import com.android.shelfLife.ui.navigation.Screen
 import com.android.shelfLife.ui.theme.ShelfLifeTheme
 
 class MainActivity : ComponentActivity() {
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
-
     setContent { ShelfLifeTheme { ShelfLifeApp() } }
-
-    checkCameraPermission()
-  }
-
-  private fun checkCameraPermission() {
-    if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) !=
-        PackageManager.PERMISSION_GRANTED) {
-      ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CAMERA), 101)
-    }
-  }
-
-  // Handle permission result
-  override fun onRequestPermissionsResult(
-      requestCode: Int,
-      permissions: Array<String>,
-      grantResults: IntArray
-  ) {
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-
-    if (requestCode == 101) {
-      if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        Toast.makeText(this, "Camera permission granted", Toast.LENGTH_SHORT).show()
-        // Proceed to show camera
-      } else {
-        Toast.makeText(
-                this,
-                "Camera permission denied. Please grant permission to use the camera.",
-                Toast.LENGTH_LONG)
-            .show()
-        // Inform the user that they cannot use the feature without the permission
-        showPermissionDeniedMessage()
-      }
-    }
-  }
-
-  private fun showPermissionDeniedMessage() {
-    // You can show a dialog or use a Composable to explain why the permission is needed
-    Toast.makeText(this, "Camera permission is required to scan barcodes.", Toast.LENGTH_LONG)
-        .show()
   }
 }
 
@@ -83,12 +39,13 @@ fun ShelfLifeApp() {
     ) {
       composable(Screen.AUTH) { SignInScreen(navigationActions) }
     }
-    navigation(startDestination = Screen.OVERVIEW, route = Route.OVERVIEW) {
-      composable(Screen.OVERVIEW) { BarcodeScannerScreen(navigationActions) }
-      // Barcode Scanner route
-      composable(Screen.OVERVIEW) {
-        BarcodeScannerScreen(navigationActions) // Show Barcode Scanner after sign-in
-      }
+
+    navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.OVERVIEW) {
+      composable(Screen.PERMISSION_HANDLER) { CameraPermissionHandler(navigationActions) }
+      composable(Screen.BARCODE_SCANNER) { BarcodeScannerScreen(navigationActions) }
+      composable(Screen.PERMISSION_DENIED) {
+        PermissionDeniedScreen(navigationActions)
+      } // For handling denied permission
     }
   }
 }

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -40,7 +40,7 @@ fun ShelfLifeApp() {
       composable(Screen.AUTH) { SignInScreen(navigationActions) }
     }
 
-    navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.OVERVIEW) {
+    navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.SCANNER) {
       composable(Screen.PERMISSION_HANDLER) { CameraPermissionHandler(navigationActions) }
       composable(Screen.BARCODE_SCANNER) { BarcodeScannerScreen(navigationActions) }
       composable(Screen.PERMISSION_DENIED) {

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -1,10 +1,15 @@
 package com.android.shelfLife
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -21,11 +26,47 @@ class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
-    setContent {
-      ShelfLifeTheme {
-        ShelfLifeApp() // Start the navigation and app setup
+
+    setContent { ShelfLifeTheme { ShelfLifeApp() } }
+
+    checkCameraPermission()
+  }
+
+  private fun checkCameraPermission() {
+    if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) !=
+        PackageManager.PERMISSION_GRANTED) {
+      ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CAMERA), 101)
+    }
+  }
+
+  // Handle permission result
+  override fun onRequestPermissionsResult(
+      requestCode: Int,
+      permissions: Array<String>,
+      grantResults: IntArray
+  ) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
+    if (requestCode == 101) {
+      if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        Toast.makeText(this, "Camera permission granted", Toast.LENGTH_SHORT).show()
+        // Proceed to show camera
+      } else {
+        Toast.makeText(
+                this,
+                "Camera permission denied. Please grant permission to use the camera.",
+                Toast.LENGTH_LONG)
+            .show()
+        // Inform the user that they cannot use the feature without the permission
+        showPermissionDeniedMessage()
       }
     }
+  }
+
+  private fun showPermissionDeniedMessage() {
+    // You can show a dialog or use a Composable to explain why the permission is needed
+    Toast.makeText(this, "Camera permission is required to scan barcodes.", Toast.LENGTH_LONG)
+        .show()
   }
 }
 

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -1,19 +1,19 @@
 package com.android.shelfLife
 
-import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
-import com.android.shelfLife.ui.camera.CameraPreviewView
-import com.android.shelfLife.ui.camera.startCamera
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navigation
+import com.android.shelfLife.ui.authentication.SignInScreen
+import com.android.shelfLife.ui.camera.BarcodeScannerScreen
+import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Route
+import com.android.shelfLife.ui.navigation.Screen
 import com.android.shelfLife.ui.theme.ShelfLifeTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,43 +21,33 @@ class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
-
-    // Check for camera permissions
-    if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) !=
-        PackageManager.PERMISSION_GRANTED) {
-      ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CAMERA), 101)
-    } else {
-      showBarcodeScannerScreen()
+    setContent {
+      ShelfLifeTheme {
+        ShelfLifeApp() // Start the navigation and app setup
+      }
     }
-  }
-
-  // Handle the permission result
-  override fun onRequestPermissionsResult(
-      requestCode: Int,
-      permissions: Array<String>,
-      grantResults: IntArray
-  ) {
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-    if (requestCode == 101 &&
-        grantResults.isNotEmpty() &&
-        grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-      showBarcodeScannerScreen() // Permission granted, start the camera
-    } else {
-      // Permission denied: Handle it here (e.g., show a message to the user)
-    }
-  }
-
-  // Set the content to show the barcode scanner screen
-  private fun showBarcodeScannerScreen() {
-    setContent { ShelfLifeTheme { BarcodeScannerScreen() } }
   }
 }
 
 @Composable
-fun BarcodeScannerScreen() {
-  val context = LocalContext.current
+fun ShelfLifeApp() {
+  val navController = rememberNavController()
+  val navigationActions = NavigationActions(navController)
 
-  CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
-    startCamera(context, previewView) // This will initialize CameraX
+  NavHost(navController = navController, startDestination = Route.AUTH) {
+    // Authentication route
+    navigation(
+        startDestination = Screen.AUTH,
+        route = Route.AUTH,
+    ) {
+      composable(Screen.AUTH) { SignInScreen(navigationActions) }
+    }
+    navigation(startDestination = Screen.OVERVIEW, route = Route.OVERVIEW) {
+      composable(Screen.OVERVIEW) { BarcodeScannerScreen(navigationActions) }
+      // Barcode Scanner route
+      composable(Screen.OVERVIEW) {
+        BarcodeScannerScreen(navigationActions) // Show Barcode Scanner after sign-in
+      }
+    }
   }
 }

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -1,42 +1,63 @@
 package com.android.shelfLife
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.compose.rememberNavController
-import com.android.shelfLife.ui.authentication.SignInScreen
-import com.android.shelfLife.ui.navigation.NavigationActions
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.android.shelfLife.ui.camera.CameraPreviewView
+import com.android.shelfLife.ui.camera.startCamera
 import com.android.shelfLife.ui.theme.ShelfLifeTheme
 
 class MainActivity : ComponentActivity() {
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
-    setContent {
-      ShelfLifeTheme {
-        Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-          SignInScreen(navigationActions = NavigationActions(rememberNavController()))
-        }
-      }
+
+    // Check for camera permissions
+    if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) !=
+        PackageManager.PERMISSION_GRANTED) {
+      ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CAMERA), 101)
+    } else {
+      showBarcodeScannerScreen()
     }
+  }
+
+  // Handle the permission result
+  override fun onRequestPermissionsResult(
+      requestCode: Int,
+      permissions: Array<String>,
+      grantResults: IntArray
+  ) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    if (requestCode == 101 &&
+        grantResults.isNotEmpty() &&
+        grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      showBarcodeScannerScreen() // Permission granted, start the camera
+    } else {
+      // Permission denied: Handle it here (e.g., show a message to the user)
+    }
+  }
+
+  // Set the content to show the barcode scanner screen
+  private fun showBarcodeScannerScreen() {
+    setContent { ShelfLifeTheme { BarcodeScannerScreen() } }
   }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-  Text(text = "Hello $name!", modifier = modifier)
-}
+fun BarcodeScannerScreen() {
+  val context = LocalContext.current
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-  ShelfLifeTheme { Greeting("Android") }
+  CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
+    startCamera(context, previewView) // This will initialize CameraX
+  }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/authentication/SignIn.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.shelfLife.R
 import com.android.shelfLife.ui.navigation.NavigationActions
-import com.android.shelfLife.ui.navigation.Route
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -44,97 +43,97 @@ import kotlinx.coroutines.tasks.await
 
 @Composable
 fun SignInScreen(navigationActions: NavigationActions) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    val launcher =
-        rememberFirebaseAuthLauncher(
-            onAuthComplete = { result ->
-                Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
-                Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
-//                navigationActions.navigateTo(Route.OVERVIEW)
-            },
-            onAuthError = {
-                Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")
-                Toast.makeText(context, "Login Failed!", Toast.LENGTH_LONG).show()
-            })
-    val token = stringResource(R.string.default_web_client_id)
-    // The main container for the screen
+  val launcher =
+      rememberFirebaseAuthLauncher(
+          onAuthComplete = { result ->
+            Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
+            Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
+            //                navigationActions.navigateTo(Route.OVERVIEW)
+          },
+          onAuthError = {
+            Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")
+            Toast.makeText(context, "Login Failed!", Toast.LENGTH_LONG).show()
+          })
+  val token = stringResource(R.string.default_web_client_id)
+  // The main container for the screen
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        content = { padding ->
-            Column(
-                modifier = Modifier.fillMaxSize().padding(padding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                // App Logo Image
-                Image(
-                    painter = painterResource(id = R.drawable.app_logo), // Ensure this drawable exists
-                    contentDescription = "App Logo",
-                    modifier = Modifier.size(250.dp))
+  Scaffold(
+      modifier = Modifier.fillMaxSize(),
+      content = { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+          // App Logo Image
+          Image(
+              painter = painterResource(id = R.drawable.app_logo), // Ensure this drawable exists
+              contentDescription = "App Logo",
+              modifier = Modifier.size(250.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
+          Spacer(modifier = Modifier.height(16.dp))
 
-                // Welcome Text
-                Text(
-                    modifier = Modifier.testTag("loginTitle"),
-                    text = "Welcome",
-                    style =
-                    MaterialTheme.typography.headlineLarge.copy(fontSize = 57.sp, lineHeight = 64.sp),
-                    fontWeight = FontWeight.Bold,
-                    // center the text
+          // Welcome Text
+          Text(
+              modifier = Modifier.testTag("loginTitle"),
+              text = "Welcome",
+              style =
+                  MaterialTheme.typography.headlineLarge.copy(fontSize = 57.sp, lineHeight = 64.sp),
+              fontWeight = FontWeight.Bold,
+              // center the text
 
-                    textAlign = TextAlign.Center)
+              textAlign = TextAlign.Center)
 
-                Spacer(modifier = Modifier.height(48.dp))
+          Spacer(modifier = Modifier.height(48.dp))
 
-                // Authenticate With Google Button
-                GoogleSignInButton(
-                    onSignInClick = {
-                        val gso =
-                            GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                                .requestIdToken(token)
-                                .requestEmail()
-                                .build()
-                        val googleSignInClient = GoogleSignIn.getClient(context, gso)
-                        launcher.launch(googleSignInClient.signInIntent)
-                    })
-            }
-        })
+          // Authenticate With Google Button
+          GoogleSignInButton(
+              onSignInClick = {
+                val gso =
+                    GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                        .requestIdToken(token)
+                        .requestEmail()
+                        .build()
+                val googleSignInClient = GoogleSignIn.getClient(context, gso)
+                launcher.launch(googleSignInClient.signInIntent)
+              })
+        }
+      })
 }
 
 @Composable
 fun GoogleSignInButton(onSignInClick: () -> Unit) {
-    Button(
-        onClick = onSignInClick,
-        colors = ButtonDefaults.buttonColors(containerColor = Color.White), // Button color
-        shape = RoundedCornerShape(50), // Circular edges for the button
-        border = BorderStroke(1.dp, Color.LightGray),
-        modifier =
-        Modifier.padding(8.dp)
-            .height(48.dp) // Adjust height as needed
-            .testTag("loginButton")) {
+  Button(
+      onClick = onSignInClick,
+      colors = ButtonDefaults.buttonColors(containerColor = Color.White), // Button color
+      shape = RoundedCornerShape(50), // Circular edges for the button
+      border = BorderStroke(1.dp, Color.LightGray),
+      modifier =
+          Modifier.padding(8.dp)
+              .height(48.dp) // Adjust height as needed
+              .testTag("loginButton")) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth()) {
-            // Load the Google logo from resources
-            Image(
-                painter = painterResource(id = R.drawable.google_logo),
-                contentDescription = "Google Logo",
-                modifier =
-                Modifier.size(30.dp) // Size of the Google logo
-                    .padding(end = 8.dp))
+              // Load the Google logo from resources
+              Image(
+                  painter = painterResource(id = R.drawable.google_logo),
+                  contentDescription = "Google Logo",
+                  modifier =
+                      Modifier.size(30.dp) // Size of the Google logo
+                          .padding(end = 8.dp))
 
-            // Text for the button
-            Text(
-                text = "Sign in with Google",
-                color = Color.Gray, // Text color
-                fontSize = 16.sp, // Font size
-                fontWeight = FontWeight.Medium)
-        }
-    }
+              // Text for the button
+              Text(
+                  text = "Sign in with Google",
+                  color = Color.Gray, // Text color
+                  fontSize = 16.sp, // Font size
+                  fontWeight = FontWeight.Medium)
+            }
+      }
 }
 
 @Composable
@@ -142,19 +141,19 @@ fun rememberFirebaseAuthLauncher(
     onAuthComplete: (AuthResult) -> Unit,
     onAuthError: (ApiException) -> Unit
 ): ManagedActivityResultLauncher<Intent, ActivityResult> {
-    val scope = rememberCoroutineScope()
-    return rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            result ->
-        val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
-        try {
-            val account = task.getResult(ApiException::class.java)!!
-            val credential = GoogleAuthProvider.getCredential(account.idToken!!, null)
-            scope.launch {
-                val authResult = Firebase.auth.signInWithCredential(credential).await()
-                onAuthComplete(authResult)
-            }
-        } catch (e: ApiException) {
-            onAuthError(e)
-        }
+  val scope = rememberCoroutineScope()
+  return rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+      result ->
+    val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+    try {
+      val account = task.getResult(ApiException::class.java)!!
+      val credential = GoogleAuthProvider.getCredential(account.idToken!!, null)
+      scope.launch {
+        val authResult = Firebase.auth.signInWithCredential(credential).await()
+        onAuthComplete(authResult)
+      }
+    } catch (e: ApiException) {
+      onAuthError(e)
     }
+  }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/authentication/SignIn.kt
@@ -51,7 +51,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
           onAuthComplete = { result ->
             Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
             Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
-            navigationActions.navigateTo(Route.OVERVIEW) // Navigate to the camera after sign-in
+            navigationActions.navigateTo(Route.SCANNER) // Navigate to the camera after sign-in
           },
           onAuthError = {
             Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")

--- a/app/src/main/java/com/android/shelfLife/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/authentication/SignIn.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.shelfLife.R
 import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Route
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -50,87 +51,71 @@ fun SignInScreen(navigationActions: NavigationActions) {
           onAuthComplete = { result ->
             Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
             Toast.makeText(context, "Login successful!", Toast.LENGTH_LONG).show()
-            //                navigationActions.navigateTo(Route.OVERVIEW)
+            navigationActions.navigateTo(Route.OVERVIEW) // Navigate to the camera after sign-in
           },
           onAuthError = {
             Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")
             Toast.makeText(context, "Login Failed!", Toast.LENGTH_LONG).show()
           })
-  val token = stringResource(R.string.default_web_client_id)
-  // The main container for the screen
 
-  Scaffold(
-      modifier = Modifier.fillMaxSize(),
-      content = { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-          // App Logo Image
+  val token = stringResource(R.string.default_web_client_id)
+
+  Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
+    Column(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center) {
           Image(
-              painter = painterResource(id = R.drawable.app_logo), // Ensure this drawable exists
+              painter = painterResource(id = R.drawable.app_logo),
               contentDescription = "App Logo",
               modifier = Modifier.size(250.dp))
 
           Spacer(modifier = Modifier.height(16.dp))
 
-          // Welcome Text
           Text(
               modifier = Modifier.testTag("loginTitle"),
               text = "Welcome",
               style =
                   MaterialTheme.typography.headlineLarge.copy(fontSize = 57.sp, lineHeight = 64.sp),
               fontWeight = FontWeight.Bold,
-              // center the text
-
               textAlign = TextAlign.Center)
 
           Spacer(modifier = Modifier.height(48.dp))
 
-          // Authenticate With Google Button
-          GoogleSignInButton(
-              onSignInClick = {
-                val gso =
-                    GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                        .requestIdToken(token)
-                        .requestEmail()
-                        .build()
-                val googleSignInClient = GoogleSignIn.getClient(context, gso)
-                launcher.launch(googleSignInClient.signInIntent)
-              })
+          GoogleSignInButton {
+            val gso =
+                GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                    .requestIdToken(token)
+                    .requestEmail()
+                    .build()
+            val googleSignInClient = GoogleSignIn.getClient(context, gso)
+            launcher.launch(googleSignInClient.signInIntent)
+          }
         }
-      })
+  }
 }
 
 @Composable
 fun GoogleSignInButton(onSignInClick: () -> Unit) {
   Button(
       onClick = onSignInClick,
-      colors = ButtonDefaults.buttonColors(containerColor = Color.White), // Button color
-      shape = RoundedCornerShape(50), // Circular edges for the button
+      colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+      shape = RoundedCornerShape(50),
       border = BorderStroke(1.dp, Color.LightGray),
-      modifier =
-          Modifier.padding(8.dp)
-              .height(48.dp) // Adjust height as needed
-              .testTag("loginButton")) {
+      modifier = Modifier.padding(8.dp).height(48.dp).testTag("loginButton")) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth()) {
-              // Load the Google logo from resources
               Image(
                   painter = painterResource(id = R.drawable.google_logo),
                   contentDescription = "Google Logo",
-                  modifier =
-                      Modifier.size(30.dp) // Size of the Google logo
-                          .padding(end = 8.dp))
+                  modifier = Modifier.size(30.dp).padding(end = 8.dp))
 
-              // Text for the button
               Text(
                   text = "Sign in with Google",
-                  color = Color.Gray, // Text color
-                  fontSize = 16.sp, // Font size
+                  color = Color.Gray,
+                  fontSize = 16.sp,
                   fontWeight = FontWeight.Medium)
             }
       }

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraPermissionHandler.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraPermissionHandler.kt
@@ -1,0 +1,36 @@
+package com.android.shelfLife.ui.camera
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Screen
+
+@Composable
+fun CameraPermissionHandler(navigationActions: NavigationActions) {
+  val context = LocalContext.current
+  val activity = context as ComponentActivity
+
+  when {
+    // If the permission is granted, navigate to the camera screen
+    ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+        PackageManager.PERMISSION_GRANTED -> {
+      navigationActions.navigateTo(Screen.BARCODE_SCANNER)
+    }
+
+    // If the permission was denied previously, show permission denied screen
+    ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA) -> {
+      navigationActions.navigateTo(Screen.PERMISSION_DENIED)
+    }
+
+    // First time asking for permission, show the permission request pop-up
+    else -> {
+      ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.CAMERA), 101)
+      navigationActions.navigateTo(Screen.PERMISSION_HANDLER)
+    }
+  }
+}

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraPreview.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraPreview.kt
@@ -1,0 +1,47 @@
+package com.android.shelfLife.ui.camera
+
+import android.content.Context
+import android.util.Log
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+
+@Composable
+fun CameraPreviewView(modifier: Modifier = Modifier, startCamera: (PreviewView) -> Unit) {
+  AndroidView(
+      factory = { context ->
+        val previewView = PreviewView(context)
+        startCamera(previewView)
+        previewView
+      },
+      modifier = modifier.fillMaxSize())
+}
+
+fun startCamera(context: Context, previewView: PreviewView) {
+  val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+
+  cameraProviderFuture.addListener(
+      {
+        val cameraProvider = cameraProviderFuture.get()
+
+        val preview =
+            Preview.Builder().build().also { it.setSurfaceProvider(previewView.surfaceProvider) }
+
+        val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+        try {
+          cameraProvider.unbindAll()
+          cameraProvider.bindToLifecycle(context as LifecycleOwner, cameraSelector, preview)
+        } catch (exc: Exception) {
+          Log.e("CameraX", "Use case binding failed", exc)
+        }
+      },
+      ContextCompat.getMainExecutor(context))
+}

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraView.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraView.kt
@@ -1,16 +1,29 @@
 package com.android.shelfLife.ui.camera
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Log
+import androidx.activity.ComponentActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.android.shelfLife.ui.navigation.NavigationActions
@@ -18,9 +31,20 @@ import com.android.shelfLife.ui.navigation.NavigationActions
 @Composable
 fun BarcodeScannerScreen(navigationActions: NavigationActions) {
   val context = LocalContext.current
+  val permissionGranted =
+      ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+          PackageManager.PERMISSION_GRANTED
 
-  CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
-    startCamera(context, previewView) // This will initialize CameraX
+  if (permissionGranted) {
+    CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
+      startCamera(context, previewView)
+    }
+  } else {
+    PermissionDeniedScreen(
+        onRequestPermissionAgain = {
+          ActivityCompat.requestPermissions(
+              context as ComponentActivity, arrayOf(Manifest.permission.CAMERA), 101)
+        })
   }
 }
 
@@ -55,4 +79,16 @@ fun startCamera(context: Context, previewView: PreviewView) {
         }
       },
       ContextCompat.getMainExecutor(context))
+}
+
+@Composable
+fun PermissionDeniedScreen(onRequestPermissionAgain: () -> Unit) {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = "Camera permission is required to scan barcodes.")
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onRequestPermissionAgain) { Text(text = "Grant Permission") }
+      }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraView.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraView.kt
@@ -9,9 +9,20 @@ import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
+import com.android.shelfLife.ui.navigation.NavigationActions
+
+@Composable
+fun BarcodeScannerScreen(navigationActions: NavigationActions) {
+  val context = LocalContext.current
+
+  CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
+    startCamera(context, previewView) // This will initialize CameraX
+  }
+}
 
 @Composable
 fun CameraPreviewView(modifier: Modifier = Modifier, startCamera: (PreviewView) -> Unit) {

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraView.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraView.kt
@@ -1,10 +1,7 @@
 package com.android.shelfLife.ui.camera
 
-import android.Manifest
 import android.content.Context
-import android.content.pm.PackageManager
 import android.util.Log
-import androidx.activity.ComponentActivity
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -14,7 +11,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,28 +19,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
+import com.android.shelfLife.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Route
+import com.android.shelfLife.ui.navigation.TopLevelDestination
 
 @Composable
 fun BarcodeScannerScreen(navigationActions: NavigationActions) {
+  // Get the context in a Composable way
   val context = LocalContext.current
-  val permissionGranted =
-      ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
-          PackageManager.PERMISSION_GRANTED
 
-  if (permissionGranted) {
-    CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
-      startCamera(context, previewView)
-    }
-  } else {
-    PermissionDeniedScreen(
-        onRequestPermissionAgain = {
-          ActivityCompat.requestPermissions(
-              context as ComponentActivity, arrayOf(Manifest.permission.CAMERA), 101)
-        })
+  // Pass the context and start the camera in the lambda
+  CameraPreviewView(modifier = Modifier.fillMaxSize()) { previewView ->
+    startCamera(context, previewView) // Now using the context outside the lambda
   }
 }
 
@@ -53,7 +42,7 @@ fun CameraPreviewView(modifier: Modifier = Modifier, startCamera: (PreviewView) 
   AndroidView(
       factory = { context ->
         val previewView = PreviewView(context)
-        startCamera(previewView)
+        startCamera(previewView) // Call the regular Kotlin function here
         previewView
       },
       modifier = modifier.fillMaxSize())
@@ -82,13 +71,19 @@ fun startCamera(context: Context, previewView: PreviewView) {
 }
 
 @Composable
-fun PermissionDeniedScreen(onRequestPermissionAgain: () -> Unit) {
+fun PermissionDeniedScreen(navigationActions: NavigationActions) {
   Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp),
+      modifier = Modifier.fillMaxSize(),
       verticalArrangement = Arrangement.Center,
       horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(text = "Camera permission is required to scan barcodes.")
+        Text(text = "Camera permission is required to scan barcodes. Go to Settings -> ShelfLife -> Camera Permission and enable it. ")
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onRequestPermissionAgain) { Text(text = "Grant Permission") }
+        Button(
+            onClick = {
+              // Optionally prompt user to go to settings to enable permissions
+              navigationActions.navigateTo(Route.AUTH)
+            }) {
+              Text(text = "Go Back")
+            }
       }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/navigation/NavigationActions.kt
@@ -16,8 +16,10 @@ object Screen {
   const val OVERVIEW = "Overview Screen"
   const val ADD_TODO = "Add ToDo Screen"
   const val AUTH = "Auth Screen"
-  const val MAP = "Map Screen"
+  const val BARCODE_SCANNER = "Barcode Scanner Screen"
+  const val PERMISSION_HANDLER = "Permission Handler Screen"
   const val EDIT_TODO = "Edit ToDo Screen"
+  const val PERMISSION_DENIED = "Permission Denied Screen"
   // Add other screens as needed
 }
 

--- a/app/src/test/java/com/android/shelflife/ExampleUnitTest.kt
+++ b/app/src/test/java/com/android/shelflife/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.android.shelflife
 
-import org.junit.Test
-
 import org.junit.Assert.*
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -10,8 +9,8 @@ import org.junit.Assert.*
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 class ExampleUnitTest {
-    @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
-    }
+  @Test
+  fun addition_isCorrect() {
+    assertEquals(4, 2 + 2)
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ ktfmt = "0.17.0"
 # Barcode Scanner
 mlkit-barcode-scanning = "17.0.2"
 camerax = "1.0.2"
+guava = "31.1-jre"
 
 
 
@@ -126,7 +127,7 @@ mlkit-barcode-scanning = { group = "com.google.mlkit", name = "barcode-scanning"
 camerax-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
 camerax-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 camerax-view = { group = "androidx.camera", name = "camera-view", version = "1.0.0-alpha27" }
-
+guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,10 @@ kotlin = "1.9.0"
 gms = "4.4.2"
 ktfmt = "0.17.0"
 
+# Barcode Scanner
+mlkit-barcode-scanning = "17.0.2"
+camerax = "1.0.2"
+
 
 
 # UI Compose
@@ -118,7 +122,10 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "androidxCoreKtx" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "material" }
-
+mlkit-barcode-scanning = { group = "com.google.mlkit", name = "barcode-scanning", version.ref = "mlkit-barcode-scanning" }
+camerax-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
+camerax-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
+camerax-view = { group = "androidx.camera", name = "camera-view", version = "1.0.0-alpha27" }
 
 
 [plugins]


### PR DESCRIPTION
## Description:

This pull request integrates the camera functionality and adds navigation from the Google sign-in screen to the barcode scanner screen.

## Key Changes:

1. **Camera Integration**:
   - Implemented CameraX for live camera preview functionality in the `BarcodeScannerScreen`.
   - Handled camera permissions to ensure proper initialization when users reach the camera screen.
   - Created a `BarcodeScannerScreen` that initializes and displays the camera preview.
   
2. **Navigation Integration**:
   - Added navigation logic to transition from the Google sign-in screen to the barcode scanner screen after successful sign-in.
   - Refactored the app structure to streamline navigation between authentication and the camera view.
   - Updated `MainActivity` to use `NavHost` for managing screen transitions.

## Changes in Files:

- Refactored `MainActivity` to focus on navigation.
- Created the `BarcodeScannerScreen` for displaying the camera preview.
- Updated `ShelfLifeApp` to manage transitions between the sign-in screen and the barcode scanner.

## Testing:

- Verified that the navigation from the sign-in screen to the barcode scanner screen works as expected.
- Checked that the camera permissions are requested and the camera preview is correctly displayed after authentication.

## Related Issues:

- None

