### PR TITLE
refactor: split FoodItem into FoodItem and FoodFacts classes

### DIFF
--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
@@ -1,0 +1,60 @@
+package com.android.shelfLife.model.foodFacts
+
+/**
+ * Represents intrinsic details of a food item.
+ *
+ * This data class encapsulates all the general and unchanging information about a food item,
+ * such as its name, barcode, nutritional facts, quantity, and category. The `FoodFacts` class
+ * provides a standardized way to handle product-level data that remains consistent across
+ * different instances of the same food item.
+ *
+ * @property name The name of the food product.
+ * @property barcode The unique barcode identifier for the product.
+ * @property quantity The quantity of the product (e.g., weight, volume, or count).
+ * @property category The category of the food item (e.g., FRUIT, VEGETABLE, MEAT).
+ * @property nutritionFacts Detailed nutritional information per 100g/ml of the product.
+ */
+
+data class FoodFacts(
+    val name: String, // Name of the food item
+    val barcode: String = "", // Barcode number
+    val quantity: Quantity, // Quantity of the food item
+    val category: FoodCategory = FoodCategory.OTHER, // Default category is OTHER
+    val nutritionFacts: NutritionFacts = NutritionFacts() // Default empty NutritionFacts object
+)
+
+data class Quantity(
+    val amount: Double, // Amount of the quantity
+    val unit: FoodUnit = FoodUnit.GRAM // Unit of the quantity
+)
+
+enum class FoodUnit {
+    GRAM, // Gram unit
+    ML, // Milliliter unit
+    COUNT // Item count (2 pineapples, 3 apples, etc.)
+}
+
+enum class FoodCategory {
+    FRUIT, // Fruit category
+    VEGETABLE, // Vegetable category
+    MEAT, // Meat category
+    DAIRY, // Dairy category
+    GRAIN, // Grain category
+    BEVERAGE, // Beverage category
+    SNACK, // Snack category
+    OTHER // Other category
+}
+
+/**
+ * This data class represents the nutrition facts for a food item per 100g/100ml, with default
+ * values.
+ */
+data class NutritionFacts(
+    val energyKcal: Int = 0, // Default energy in kilocalories per 100g/ml
+    val fat: Double = 0.0, // Default fat value is 0.0 if not provided
+    val saturatedFat: Double = 0.0, // Default saturated fat value is 0.0 if not provided
+    val carbohydrates: Double = 0.0, // Default carbohydrates is 0.0 if not provided
+    val sugars: Double = 0.0, // Default sugars value is 0.0 if not provided
+    val proteins: Double = 0.0, // Default proteins value is 0.0
+    val salt: Double = 0.0, // Default salt value is 0.0
+)

--- a/app/src/main/java/com/android/shelfLife/model/foodItem/FoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodItem/FoodItem.kt
@@ -1,41 +1,37 @@
 package com.android.shelfLife.model.foodItem
 
+import com.android.shelfLife.model.foodFacts.FoodFacts
 import com.google.firebase.Timestamp
 
+/**
+ * Represents details of a specific food item in a user's household.
+ *
+ * The `FoodItem` class encapsulates all details that are specific to an instance of a product
+ * as it exists in the user's possession, distinct from general product information.
+ *
+ * @property uid Unique identifier for the food item instance.
+ * @property foodFacts General product information (e.g., name, barcode, nutritional facts) shared
+ * across all instances of this food item.
+ * @property status Current status of the food item (e.g., OPEN, CLOSED, EXPIRED).
+ * @property location Physical location of the food item within the household (e.g., pantry, fridge).
+ * @property expiryDate Expiry date of the food item, if available.
+ * @property openDate The date the food item was opened, if applicable.
+ * @property buyDate The date the food item was purchased or added to inventory.
+ */
 data class FoodItem(
     val uid: String, // Unique ID of the food item
-    val name: String, // Name of the food item
-    val barcode: String = "", // Barcode number, default to an empty string if not provided
-    val quantity: Quantity, // Quantity of the food item
-    val status: FoodStatus = FoodStatus.CLOSED, // Default status is CLOSED
-    val nutritionFacts: NutritionFacts = NutritionFacts(), // Default empty NutritionFacts object
-    val foodCategory: FoodCategory = FoodCategory.OTHER, // Default category is OTHER
-    val location: FoodLocation = FoodLocation(0, _Location.PANTRY), // Default location is PANTRY
+    val foodFacts: FoodFacts, // Food facts of the food item
+    val location: FoodLocation = FoodLocation(0, FoodStorageLocation.PANTRY), // Default location is PANTRY
     val expiryDate: Timestamp? = null, // Expiry date can be null if not provided
     val openDate: Timestamp? = null, // Expiry date can be null if not provided
     val buyDate: Timestamp = Timestamp.now(), // Default buy date is the current time
-)
-
-data class Quantity(
-    val amount: Double, // Amount of the quantity
-    val unit: FoodUnit = FoodUnit.GRAM // Unit of the quantity
+    val status: FoodStatus = FoodStatus.CLOSED // Default status is CLOSED
 )
 
 data class FoodLocation(
     val householdNumber: Int, // Household number
-    val location: _Location // Location can be PANTRY, FRIDGE, or FREEZER
+    val storageLocation: FoodStorageLocation // Location can be PANTRY, FRIDGE, or FREEZER
 )
-
-enum class FoodCategory {
-    FRUIT, // Fruit category
-    VEGETABLE, // Vegetable category
-    MEAT, // Meat category
-    DAIRY, // Dairy category
-    GRAIN, // Grain category
-    BEVERAGE, // Beverage category
-    SNACK, // Snack category
-    OTHER // Other category
-}
 
 /** This enum class represents the status of a food item. */
 enum class FoodStatus {
@@ -44,29 +40,8 @@ enum class FoodStatus {
     EXPIRED // Food item has expired
 }
 
-/**
- * This data class represents the nutrition facts for a food item per 100g/100ml, with default
- * values.
- */
-data class NutritionFacts(
-    val energyKcal: Int = 0, // Default energy in kilocalories per 100g/ml
-    val fat: Double = 0.0, // Default fat value is 0.0 if not provided
-    val saturatedFat: Double = 0.0, // Default saturated fat value is 0.0 if not provided
-    val carbohydrates: Double = 0.0, // Default carbohydrates is 0.0 if not provided
-    val sugars: Double = 0.0, // Default sugars value is 0.0 if not provided
-    val proteins: Double = 0.0, // Default proteins value is 0.0
-    val salt: Double = 0.0, // Default salt value is 0.0
-)
-
-
-enum class _Location {
+enum class FoodStorageLocation {
     PANTRY, // Pantry location
     FRIDGE, // Fridge location
     FREEZER, // Freezer location
-}
-
-enum class FoodUnit {
-    GRAM, // Gram unit
-    ML, // Milliliter unit
-    COUNT // Item count (2 pineapples, 3 apples, etc.)
 }

--- a/app/src/main/java/com/android/shelfLife/model/foodItem/FoodItemViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodItem/FoodItemViewModel.kt
@@ -1,0 +1,3 @@
+package com.android.shelfLife.model.foodItem
+
+class FoodItemViewModel {}


### PR DESCRIPTION
### **Summary**
This pull request refactors the existing `FoodItem` class by splitting it into two distinct classes: `FoodItem` and `FoodFacts`. The goal is to separate intrinsic product properties from instance-specific user data, improving code modularity and maintainability.

### **Key Changes**
- Created a new `FoodFacts` class to handle intrinsic product data.
- Updated the `FoodItem` class to include a `FoodFacts` object and focus on user-specific properties.
- Refactored existing code to adopt the new data model structure.
- Updated tests to ensure compatibility with the new `FoodItem` and `FoodFacts` classes.

### ⚠️ **Breaking Changes**
- **All classes or functions that previously relied on the old `FoodItem` data structure are now **deprecated** and require updates to integrate with the new `FoodItem` and `FoodFacts` model.**

### **Motivation**
The primary motivation for this refactor is to create a clear distinction between general product properties and specific user-related data, aligning with clean code principles and making the codebase more scalable and maintainable.

### **How to Test**
1. Run all unit tests to ensure they pass with the updated data models.
2. Manually test any functionality that interacts with `FoodItem` or `FoodFacts` to confirm that the changes do not introduce any regressions.

### **Related Issue**
- Closes #27 - Refactor FoodItem into FoodItem and FoodFacts classes
