### PR TITLE
feat(camera-permission): handle permission states, pop-ups, and real-time UI updates

### DIFF
--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -5,10 +5,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
+import com.android.shelfLife.model.camera.BarcodeScannerViewModel
 import com.android.shelfLife.ui.authentication.SignInScreen
 import com.android.shelfLife.ui.camera.BarcodeScannerScreen
 import com.android.shelfLife.ui.camera.CameraPermissionHandler
@@ -31,6 +33,8 @@ fun ShelfLifeApp() {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
 
+  val barcodeScannerViewModel: BarcodeScannerViewModel = viewModel()
+
   NavHost(navController = navController, startDestination = Route.AUTH) {
     // Authentication route
     navigation(
@@ -41,8 +45,15 @@ fun ShelfLifeApp() {
     }
 
     navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.SCANNER) {
-      composable(Screen.PERMISSION_HANDLER) { CameraPermissionHandler(navigationActions) }
-      composable(Screen.BARCODE_SCANNER) { BarcodeScannerScreen(navigationActions) }
+      composable(Screen.PERMISSION_HANDLER) {
+        CameraPermissionHandler(navigationActions, barcodeScannerViewModel)
+      }
+      composable(Screen.BARCODE_SCANNER) {
+        BarcodeScannerScreen(navigationActions, barcodeScannerViewModel)
+      }
+      composable(Screen.PERMISSION_DENIED) {
+        PermissionDeniedScreen()
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -43,9 +43,6 @@ fun ShelfLifeApp() {
     navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.SCANNER) {
       composable(Screen.PERMISSION_HANDLER) { CameraPermissionHandler(navigationActions) }
       composable(Screen.BARCODE_SCANNER) { BarcodeScannerScreen(navigationActions) }
-      composable(Screen.PERMISSION_DENIED) {
-        PermissionDeniedScreen(navigationActions)
-      } // For handling denied permission
     }
   }
 }

--- a/app/src/main/java/com/android/shelfLife/model/camera/BarcodeScannerViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/camera/BarcodeScannerViewModel.kt
@@ -1,0 +1,28 @@
+package com.android.shelfLife.model.camera
+
+import android.app.Application
+import android.content.pm.PackageManager
+import android.Manifest
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.AndroidViewModel
+
+class BarcodeScannerViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val context = getApplication<Application>().applicationContext
+
+    var permissionGranted by mutableStateOf(
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+    )
+        private set
+
+    fun checkCameraPermission() {
+        permissionGranted = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/app/src/main/java/com/android/shelfLife/model/camera/BarcodeScannerViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/camera/BarcodeScannerViewModel.kt
@@ -1,28 +1,43 @@
 package com.android.shelfLife.model.camera
 
-import android.app.Application
-import android.content.pm.PackageManager
 import android.Manifest
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 
 class BarcodeScannerViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val context = getApplication<Application>().applicationContext
+  private val context = getApplication<Application>().applicationContext
+  private val sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
 
-    var permissionGranted by mutableStateOf(
-        ContextCompat.checkSelfPermission(
-            context, Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
-    )
-        private set
+  var permissionGranted by mutableStateOf(
+    ContextCompat.checkSelfPermission(
+      context, Manifest.permission.CAMERA
+    ) == PackageManager.PERMISSION_GRANTED
+  )
+    private set
 
-    fun checkCameraPermission() {
-        permissionGranted = ContextCompat.checkSelfPermission(
-            context, Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
-    }
+  var permissionRequested by mutableStateOf(
+    sharedPreferences.getBoolean("permissionRequested", false)
+  )
+    private set
+
+  fun checkCameraPermission() {
+    permissionGranted = ContextCompat.checkSelfPermission(
+      context, Manifest.permission.CAMERA
+    ) == PackageManager.PERMISSION_GRANTED
+  }
+
+  fun onPermissionResult(isGranted: Boolean) {
+    permissionGranted = isGranted
+    permissionRequested = true
+    sharedPreferences.edit().putBoolean("permissionRequested", true).apply()
+  }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraPermissionHandler.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraPermissionHandler.kt
@@ -1,36 +1,90 @@
 package com.android.shelfLife.ui.camera
 
 import android.Manifest
+import android.app.Activity
+import android.content.Intent
 import android.content.pm.PackageManager
-import androidx.activity.ComponentActivity
-import androidx.compose.runtime.Composable
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.*
 import com.android.shelfLife.ui.navigation.NavigationActions
 import com.android.shelfLife.ui.navigation.Screen
 
 @Composable
 fun CameraPermissionHandler(navigationActions: NavigationActions) {
   val context = LocalContext.current
-  val activity = context as ComponentActivity
+  val activity = context as Activity
 
-  when {
-    // If the permission is granted, navigate to the camera screen
-    ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
-        PackageManager.PERMISSION_GRANTED -> {
+  // State to keep track of whether the permission is granted
+  var permissionGranted by remember {
+    mutableStateOf(
+      ContextCompat.checkSelfPermission(
+        context, Manifest.permission.CAMERA
+      ) == PackageManager.PERMISSION_GRANTED
+    )
+  }
+
+  // State to keep track of whether we have already requested the permission
+  var permissionRequested by remember { mutableStateOf(false) }
+
+  // Permission launcher
+  val launcher = rememberLauncherForActivityResult(
+    ActivityResultContracts.RequestPermission()
+  ) { isGranted: Boolean ->
+    permissionGranted = isGranted
+    permissionRequested = true
+  }
+
+  // Observe lifecycle to detect when the app resumes
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  DisposableEffect(lifecycleOwner) {
+    val observer = LifecycleEventObserver { _, event ->
+      if (event == Lifecycle.Event.ON_RESUME) {
+        // Re-check the permission status when the app resumes
+        val newPermissionStatus = ContextCompat.checkSelfPermission(
+          context, Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (permissionGranted != newPermissionStatus) {
+          permissionGranted = newPermissionStatus
+        }
+      }
+    }
+
+    lifecycleOwner.lifecycle.addObserver(observer)
+
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+    }
+  }
+
+  // Navigate to the camera screen when permission is granted
+  LaunchedEffect(permissionGranted) {
+    if (permissionGranted) {
       navigationActions.navigateTo(Screen.BARCODE_SCANNER)
     }
+  }
 
-    // If the permission was denied previously, show permission denied screen
-    ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA) -> {
-      navigationActions.navigateTo(Screen.PERMISSION_DENIED)
+  when {
+    permissionGranted -> {
+      // Permission is granted; navigation is handled in LaunchedEffect
     }
-
-    // First time asking for permission, show the permission request pop-up
+    !permissionRequested -> {
+      // First-time request: show the standard permission pop-up
+      SideEffect {
+        launcher.launch(Manifest.permission.CAMERA)
+      }
+    }
     else -> {
-      ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.CAMERA), 101)
-      navigationActions.navigateTo(Screen.PERMISSION_HANDLER)
+      // Permission denied: show the PermissionDeniedScreen
+      PermissionDeniedScreen()
     }
   }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/camera/CameraPermissionHandler.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/CameraPermissionHandler.kt
@@ -2,9 +2,7 @@ package com.android.shelfLife.ui.camera
 
 import android.Manifest
 import android.app.Activity
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.*
@@ -13,48 +11,35 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.*
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.shelfLife.model.camera.BarcodeScannerViewModel
 import com.android.shelfLife.ui.navigation.NavigationActions
 import com.android.shelfLife.ui.navigation.Screen
 
 @Composable
-fun CameraPermissionHandler(navigationActions: NavigationActions) {
+fun CameraPermissionHandler(
+  navigationActions: NavigationActions,
+  viewModel: BarcodeScannerViewModel = viewModel()
+) {
   val context = LocalContext.current
   val activity = context as Activity
 
-  // State to keep track of whether the permission is granted
-  var permissionGranted by remember {
-    mutableStateOf(
-      ContextCompat.checkSelfPermission(
-        context, Manifest.permission.CAMERA
-      ) == PackageManager.PERMISSION_GRANTED
-    )
-  }
+  val permissionGranted = viewModel.permissionGranted
 
-  // State to keep track of whether we have already requested the permission
-  var permissionRequested by remember { mutableStateOf(false) }
-
-  // Permission launcher
+  // For triggering permission requests
   val launcher = rememberLauncherForActivityResult(
     ActivityResultContracts.RequestPermission()
   ) { isGranted: Boolean ->
-    permissionGranted = isGranted
-    permissionRequested = true
+    viewModel.onPermissionResult(isGranted) // Update permission result in ViewModel
   }
 
   // Observe lifecycle to detect when the app resumes
   val lifecycleOwner = LocalLifecycleOwner.current
-
   DisposableEffect(lifecycleOwner) {
     val observer = LifecycleEventObserver { _, event ->
       if (event == Lifecycle.Event.ON_RESUME) {
         // Re-check the permission status when the app resumes
-        val newPermissionStatus = ContextCompat.checkSelfPermission(
-          context, Manifest.permission.CAMERA
-        ) == PackageManager.PERMISSION_GRANTED
-
-        if (permissionGranted != newPermissionStatus) {
-          permissionGranted = newPermissionStatus
-        }
+        viewModel.checkCameraPermission()
       }
     }
 
@@ -65,26 +50,47 @@ fun CameraPermissionHandler(navigationActions: NavigationActions) {
     }
   }
 
-  // Navigate to the camera screen when permission is granted
-  LaunchedEffect(permissionGranted) {
+  // Check if we should show a rationale for the permission
+  var shouldShowRationale by remember { mutableStateOf(false) }
+
+  LaunchedEffect(Unit) {
+    shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(
+      activity,
+      Manifest.permission.CAMERA
+    )
+  }
+
+  // Core logic for handling permission states
+  LaunchedEffect(permissionGranted, shouldShowRationale) {
     if (permissionGranted) {
+      // If permission is granted, navigate to the camera screen
       navigationActions.navigateTo(Screen.BARCODE_SCANNER)
+    } else {
+      val currentPermissionStatus = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.CAMERA
+      )
+
+      when {
+        // "Don't allow" state (no pop-up, just show PermissionDeniedScreen)
+        currentPermissionStatus == PackageManager.PERMISSION_DENIED && shouldShowRationale -> {
+          // The permission is denied and should not trigger a rationale pop-up.
+          // This means the user set "Don't allow" in the settings.
+          // Show the PermissionDeniedScreen without pop-up.
+        }
+
+        // "Ask every time" state (show pop-up and PermissionDeniedScreen)
+        currentPermissionStatus == PackageManager.PERMISSION_DENIED && !shouldShowRationale -> {
+          // The permission is denied but we should show the rationale and pop-up.
+          // This means the user is in "Ask every time" mode or denied without "Don't allow."
+          launcher.launch(Manifest.permission.CAMERA)
+        }
+      }
     }
   }
 
-  when {
-    permissionGranted -> {
-      // Permission is granted; navigation is handled in LaunchedEffect
-    }
-    !permissionRequested -> {
-      // First-time request: show the standard permission pop-up
-      SideEffect {
-        launcher.launch(Manifest.permission.CAMERA)
-      }
-    }
-    else -> {
-      // Permission denied: show the PermissionDeniedScreen
-      PermissionDeniedScreen()
-    }
+  // Show the PermissionDeniedScreen if permission is not granted
+  if (!permissionGranted) {
+    PermissionDeniedScreen()
   }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to how the app manages camera permissions, pop-ups, and the camera screen's real-time behavior based on permission state changes. The following updates have been made:

Key Features and Updates:
Permission Handling for Camera Access:

Properly handles the three camera permission states:
"Allow while using the app": Navigates to the camera screen automatically.
"Ask every time": Displays the PermissionDeniedScreen and triggers the permission pop-up.
"Don't allow": Displays the PermissionDeniedScreen without triggering the pop-up.
Ensured that the permission pop-up logic is correctly tied to the appropriate states and that the UI behaves accordingly in all scenarios.
ViewModel for Permission Management:

A BarcodeScannerViewModel was created to manage the permission states across the lifecycle of the app. This centralizes the logic for handling permission status updates and ensures consistent behavior throughout the app.
The ViewModel stores whether the permission has been granted or denied and updates the UI based on the user's permission preferences.
Real-Time UI Updates for Camera Screen:

The camera screen now updates in real time based on changes to the permission state (e.g., if the user changes the permission in the app settings while the app is running).
Leveraged lifecycle observers to ensure the camera permission is re-checked whenever the app resumes, ensuring the user interface reflects the current permission state accurately without needing to restart the app.
Summary of Improvements:
The app now provides a seamless experience for handling camera permissions, with proper handling of pop-up prompts based on the permission state.
The permission logic is centralized in a new BarcodeScannerViewModel, improving maintainability and ensuring the app’s behavior is consistent across its lifecycle.
Real-time updates for the camera screen ensure that the user always sees the appropriate interface depending on their current permission settings.