### PR TITLE
fix: Change parameter modifier_input into modifier in AddFoodItem

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/overview/AddFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/AddFoodItem.kt
@@ -106,7 +106,7 @@ fun AddFoodItemScreen(
                     expanded = unitExpanded,
                     onExpandedChange = { unitExpanded = it },
                     optionLabel = { fromCapitalStringtoLowercaseString(it.name) },
-                    modifier_input = Modifier.weight(1f))
+                    modifier = Modifier.weight(1f))
               }
 
           // Category dropdown


### PR DESCRIPTION
Just an addition from #18, forgot to change modifier_input to modifier in the AddFoodItem as a fix proposed.