### PR TITLE
feat : add ProfileScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -231,6 +231,10 @@ dependencies {
     // Networking with OkHttp
     implementation(libs.okhttp)
 
+    // Image from network
+    implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
+
     // Testing Unit
     testImplementation(libs.junit)
     androidTestImplementation(libs.mockk)

--- a/app/src/androidTest/java/com/android/shelflife/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/profile/ProfileScreenTest.kt
@@ -1,0 +1,115 @@
+package com.android.shelflife.ui.profile
+
+import android.net.Uri
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Route
+import com.android.shelfLife.ui.profile.ProfileScreen
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProfileScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun testGreetingText_whenAccountIsNull_displaysGuest() {
+    val navigationActions = NavigationActions(mockk<NavHostController>(relaxed = true))
+    composeTestRule.setContent {
+      ProfileScreen(navigationActions = navigationActions, account = null)
+    }
+
+    composeTestRule
+        .onNodeWithTag("greetingText")
+        .assertIsDisplayed()
+        .assertTextEquals("Hello, Guest")
+  }
+
+  @Test
+  fun testGreetingText_whenAccountIsNotNull_displaysEmail() {
+    val navigationActions = NavigationActions(mockk<NavHostController>(relaxed = true))
+
+    val account =
+        mockk<GoogleSignInAccount>(
+            block = {
+              every { email } returns "test@example.com"
+              every { photoUrl } returns
+                  Uri.parse(
+                      "https://letsenhance.io/static/8f5e523ee6b2479e26ecc91b9c25261e/1015f/MainAfter.jpg")
+            })
+    composeTestRule.setContent {
+      ProfileScreen(navigationActions = navigationActions, account = account)
+    }
+
+    composeTestRule
+        .onNodeWithTag("greetingText")
+        .assertIsDisplayed()
+        .assertTextEquals("Hello, test@example.com")
+  }
+
+  @Test
+  fun testLogoutButtonFunctionality() {
+    val navigationActions =
+        mockk<NavigationActions>(
+            relaxed = true, block = { every { currentRoute() } returns Route.AUTH })
+    var signOutCalled = false
+    val signOutUser = { signOutCalled = true }
+
+    composeTestRule.setContent {
+      ProfileScreen(
+          navigationActions = navigationActions, account = null, signOutUser = signOutUser)
+    }
+
+    composeTestRule.onNodeWithTag("logoutButton").assertIsDisplayed().performClick()
+
+    // Check that signOutUser was called
+    assertTrue(signOutCalled)
+
+    // Check that navigation navigated to AUTH
+    assertEquals(Route.AUTH, navigationActions.currentRoute())
+  }
+
+  @Test
+  fun testProfilePictureIsDisplayed() {
+    val navigationActions = NavigationActions(mockk<NavHostController>(relaxed = true))
+    composeTestRule.setContent {
+      ProfileScreen(navigationActions = navigationActions, account = null)
+    }
+
+    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+  }
+
+  @Test
+  fun testBottomNavigationIsDisplayed() {
+    val navigationActions = NavigationActions(mockk<NavHostController>(relaxed = true))
+    composeTestRule.setContent {
+      ProfileScreen(navigationActions = navigationActions, account = null)
+    }
+
+    composeTestRule.onNodeWithText("Profile").assertIsDisplayed().assertIsSelected()
+  }
+
+  @Test
+  fun testBottomNavigationChangesSelectedRoute() {
+    val navigationActions =
+        mockk<NavigationActions>(
+            relaxed = true, block = { every { currentRoute() } returns Route.RECIPES })
+    composeTestRule.setContent {
+      ProfileScreen(navigationActions = navigationActions, account = null)
+    }
+
+    composeTestRule.onNodeWithText("Recipes").performClick()
+
+    assertEquals(Route.RECIPES, navigationActions.currentRoute())
+  }
+}

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -26,6 +26,7 @@ import com.android.shelfLife.ui.navigation.Route
 import com.android.shelfLife.ui.navigation.Screen
 import com.android.shelfLife.ui.overview.AddFoodItemScreen
 import com.android.shelfLife.ui.overview.OverviewScreen
+import com.android.shelfLife.ui.profile.ProfileScreen
 import com.android.shelfLife.ui.recipes.IndividualRecipeScreen
 import com.android.shelfLife.ui.recipes.RecipesScreen
 import com.example.compose.ShelfLifeTheme
@@ -69,7 +70,6 @@ fun ShelfLifeApp() {
         AddFoodItemScreen(navigationActions, householdViewModel, listFoodItemViewModel)
       }
     }
-
     navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.SCANNER) {
       composable(Screen.PERMISSION_HANDLER) {
         CameraPermissionHandler(navigationActions, barcodeScannerViewModel)
@@ -83,7 +83,6 @@ fun ShelfLifeApp() {
             listFoodItemViewModel)
       }
     }
-
     navigation(
         startDestination = Screen.RECIPES,
         route = Route.RECIPES,
@@ -94,6 +93,9 @@ fun ShelfLifeApp() {
       composable(Screen.INDIVIDUAL_RECIPE) {
         IndividualRecipeScreen(navigationActions, listRecipesViewModel, householdViewModel)
       }
+    }
+    navigation(startDestination = Screen.PROFILE, route = Route.PROFILE) {
+      composable(Screen.PROFILE) { ProfileScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/profile/ProfileScreen.kt
@@ -1,0 +1,103 @@
+package com.android.shelfLife.ui.profile
+
+import android.content.Context
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.android.shelfLife.ui.navigation.BottomNavigationMenu
+import com.android.shelfLife.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Route
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+
+@Composable
+fun ProfileScreen(
+    navigationActions: NavigationActions,
+    account: GoogleSignInAccount? = null,
+    signOutUser: () -> Unit = {}
+) {
+  val context = LocalContext.current
+  val currentAccount = remember { account ?: getGoogleAccount(context) }
+
+  Scaffold(
+      modifier = Modifier.testTag("profileScaffold"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { destination -> navigationActions.navigateTo(destination) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = Route.PROFILE)
+      }) { paddingValues ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(16.dp)
+                    .testTag("profileColumn"),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top) {
+              // Profile picture using Coil to load the image from a URL
+              val profileImageUrl = currentAccount?.photoUrl?.toString()
+              if (profileImageUrl == null) {
+                Image(
+                    imageVector = Icons.Outlined.AccountCircle,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.size(100.dp).clip(CircleShape).testTag("profilePicture"),
+                    contentScale = ContentScale.Crop)
+              } else {
+                AsyncImage(
+                    model = profileImageUrl,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.size(100.dp).clip(CircleShape).testTag("profilePicture"),
+                    contentScale = ContentScale.Crop)
+              }
+              Spacer(modifier = Modifier.height(32.dp))
+              Text(
+                  text = "Hello, ${currentAccount?.email ?: "Guest"}",
+                  fontWeight = FontWeight.Bold,
+                  fontSize = 28.sp,
+                  textAlign = TextAlign.Left,
+                  modifier = Modifier.testTag("greetingText"))
+
+              Spacer(modifier = Modifier.weight(1f))
+
+              // Logout button
+              OutlinedButton(
+                  onClick = {
+                    // Sign out the user
+                    signOutUser()
+                    navigationActions.navigateTo(Route.AUTH)
+                  },
+                  modifier = Modifier.fillMaxWidth().testTag("logoutButton"),
+                  border = BorderStroke(1.dp, Color.Red) // Outline color matches the current status
+                  ) {
+                    Text(text = "Log out", color = Color.Red)
+                  }
+            }
+      }
+}
+
+// Function to get the signed-in Google account
+fun getGoogleAccount(context: Context): GoogleSignInAccount? {
+  return GoogleSignIn.getLastSignedInAccount(context)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 # Plugins
 agp = "8.4.2"
+coilCompose = "3.0.0-rc01"
+coilNetworkOkhttp = "3.0.0-rc01"
 hamcrestLibrary = "2.2"
 json = "20240303"
 kotlin = "1.9.0"
@@ -98,6 +100,8 @@ androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", versi
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestManifest" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "uiTooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
 firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx", version.ref = "firebaseAuthKtx" }


### PR DESCRIPTION
## Add Profile Screen Feature
This pull request adds the profile screen for which we were marked down on in M1. It shows the current person's email and google account photo as well as a log out button which signs the person out.  The structure follows the one created by @ElMaestroZ on the Figma page.
## Profile Screen Tests
This pull request features tests for a code coverage of 85% on the added code.
There are Google Sign in tests as well as navigation tests.