### PR TITLE
Feat/132 add image fetching to foodfacts

### DIFF
--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
@@ -1,6 +1,5 @@
 package com.android.shelfLife.model.foodFacts
 
-
 /**
  * Represents intrinsic details of a food item.
  *
@@ -23,16 +22,17 @@ data class FoodFacts(
     val nutritionFacts: NutritionFacts = NutritionFacts(), // Default empty NutritionFacts object
     val imageUrl: String = DEFAULT_IMAGE_URL // New property for image URL
 ) {
-    companion object {
-        const val DEFAULT_IMAGE_URL = "https://media.istockphoto.com/id/1354776457/vector/default-image-icon-vector-missing-picture-page-for-website-design-or-mobile-app-no-photo.jpg?s=612x612&w=0&k=20&c=w3OW0wX3LyiFRuDHo9A32Q0IUMtD4yjXEvQlqyYk9O4="
-    }
+  companion object {
+    const val DEFAULT_IMAGE_URL =
+        "https://media.istockphoto.com/id/1354776457/vector/default-image-icon-vector-missing-picture-page-for-website-design-or-mobile-app-no-photo.jpg?s=612x612&w=0&k=20&c=w3OW0wX3LyiFRuDHo9A32Q0IUMtD4yjXEvQlqyYk9O4="
+  }
 
-    override fun toString(): String {
-        return "Name: $name\n" +
-            "Barcode: $barcode\n" +
-            "Quantity: $quantity\n" +
-            "Category: ${category.name}\n" +
-            "Nutrition facts: $nutritionFacts"
+  override fun toString(): String {
+    return "Name: $name\n" +
+        "Barcode: $barcode\n" +
+        "Quantity: $quantity\n" +
+        "Category: ${category.name}\n" +
+        "Nutrition facts: $nutritionFacts"
   }
 }
 

--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
@@ -1,5 +1,6 @@
 package com.android.shelfLife.model.foodFacts
 
+
 /**
  * Represents intrinsic details of a food item.
  *
@@ -20,15 +21,18 @@ data class FoodFacts(
     val quantity: Quantity, // Quantity of the food item
     val category: FoodCategory = FoodCategory.OTHER, // Default category is OTHER
     val nutritionFacts: NutritionFacts = NutritionFacts(), // Default empty NutritionFacts object
-    val imageUrl: String =
-        "https://media.istockphoto.com/id/1354776457/vector/default-image-icon-vector-missing-picture-page-for-website-design-or-mobile-app-no-photo.jpg?s=612x612&w=0&k=20&c=w3OW0wX3LyiFRuDHo9A32Q0IUMtD4yjXEvQlqyYk9O4=" // New property for image URL
+    val imageUrl: String = DEFAULT_IMAGE_URL // New property for image URL
 ) {
-  override fun toString(): String {
-    return "Name: $name\n" +
-        "Barcode: $barcode\n" +
-        "Quantity: $quantity\n" +
-        "Category: ${category.name}\n" +
-        "Nutrition facts: $nutritionFacts"
+    companion object {
+        const val DEFAULT_IMAGE_URL = "https://media.istockphoto.com/id/1354776457/vector/default-image-icon-vector-missing-picture-page-for-website-design-or-mobile-app-no-photo.jpg?s=612x612&w=0&k=20&c=w3OW0wX3LyiFRuDHo9A32Q0IUMtD4yjXEvQlqyYk9O4="
+    }
+
+    override fun toString(): String {
+        return "Name: $name\n" +
+            "Barcode: $barcode\n" +
+            "Quantity: $quantity\n" +
+            "Category: ${category.name}\n" +
+            "Nutrition facts: $nutritionFacts"
   }
 }
 

--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/OpenFoodFactsRepository.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/OpenFoodFactsRepository.kt
@@ -47,7 +47,6 @@ class OpenFoodFactsRepository(
                 val body = response.body?.string() ?: ""
                 val foodFactsList = parseFoodFactsResponse(body, searchInput)
                 Log.d("OpenFoodFactsRepository", "Food Facts: $foodFactsList")
-
                 onSuccess(foodFactsList)
               }
             })
@@ -100,6 +99,7 @@ class OpenFoodFactsRepository(
   fun extractFoodFactsFromJson(productObject: JSONObject): FoodFacts {
     val name = productObject.optString("product_name", "Unknown Product")
     val barcode = productObject.optString("code", "")
+    val imageUrl = productObject.optString("image_url", "https://media.istockphoto.com/id/1354776457/vector/default-image-icon-vector-missing-picture-page-for-website-design-or-mobile-app-no-photo.jpg?s=612x612&w=0&k=20&c=w3OW0wX3LyiFRuDHo9A32Q0IUMtD4yjXEvQlqyYk9O4=")
     val quantity = Quantity(amount = 1.0) // Assuming default quantity, adjust as needed
 
     // Map nutrition facts
@@ -124,6 +124,7 @@ class OpenFoodFactsRepository(
         barcode = barcode,
         quantity = quantity,
         category = foodCategory,
-        nutritionFacts = nutritionFacts)
+        nutritionFacts = nutritionFacts,
+        imageUrl = imageUrl)
   }
 }

--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/OpenFoodFactsRepository.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/OpenFoodFactsRepository.kt
@@ -99,7 +99,7 @@ class OpenFoodFactsRepository(
   fun extractFoodFactsFromJson(productObject: JSONObject): FoodFacts {
     val name = productObject.optString("product_name", "Unknown Product")
     val barcode = productObject.optString("code", "")
-    val imageUrl = productObject.optString("image_url", "https://media.istockphoto.com/id/1354776457/vector/default-image-icon-vector-missing-picture-page-for-website-design-or-mobile-app-no-photo.jpg?s=612x612&w=0&k=20&c=w3OW0wX3LyiFRuDHo9A32Q0IUMtD4yjXEvQlqyYk9O4=")
+    val imageUrl = productObject.optString("image_url", FoodFacts.DEFAULT_IMAGE_URL)
     val quantity = Quantity(amount = 1.0) // Assuming default quantity, adjust as needed
 
     // Map nutrition facts

--- a/app/src/main/java/com/android/shelfLife/ui/overview/AddFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/AddFoodItem.kt
@@ -1,6 +1,5 @@
 package com.android.shelfLife.ui.overview
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -78,7 +77,11 @@ fun AddFoodItemScreen(
             })
       }) { padding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(padding).testTag("addFoodItemScreen").verticalScroll(rememberScrollState()),
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .testTag("addFoodItemScreen")
+                    .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top) {
               OutlinedTextField(
@@ -95,7 +98,8 @@ fun AddFoodItemScreen(
                         onValueChange = { amount = it },
                         label = { Text(stringResource(id = R.string.amount_hint)) },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        modifier = Modifier.testTag("inputFoodAmount").weight(1f).padding(end = 4.dp))
+                        modifier =
+                            Modifier.testTag("inputFoodAmount").weight(1f).padding(end = 4.dp))
 
                     DropdownFields(
                         label = stringResource(id = R.string.unit_label),
@@ -119,7 +123,7 @@ fun AddFoodItemScreen(
                   optionLabel = { fromCapitalStringToLowercaseString(it.name) },
                   modifier = Modifier.testTag("inputFoodCategory"))
 
-          Spacer(modifier = Modifier.height(8.dp))
+              Spacer(modifier = Modifier.height(8.dp))
 
               DropdownFields(
                   label = stringResource(id = R.string.location_label),
@@ -136,8 +140,8 @@ fun AddFoodItemScreen(
                   onValueChange = { expireDate = it },
                   label = { Text(stringResource(id = R.string.expire_date_hint)) },
                   placeholder = { Text("dd/mm/yyyy") },
-                  modifier = Modifier.testTag("inputFoodExpireDate").fillMaxWidth().padding(bottom = 8.dp)
-              )
+                  modifier =
+                      Modifier.testTag("inputFoodExpireDate").fillMaxWidth().padding(bottom = 8.dp))
 
               OutlinedTextField(
                   value = openDate,

--- a/app/src/test/java/com/android/shelflife/model/foodFacts/OpenFoodFactsRepositoryTest.kt
+++ b/app/src/test/java/com/android/shelflife/model/foodFacts/OpenFoodFactsRepositoryTest.kt
@@ -13,7 +13,6 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.*
 
 class OpenFoodFactsRepositoryTest {
 

--- a/app/src/test/java/com/android/shelflife/model/foodFacts/OpenFoodFactsRepositoryTest.kt
+++ b/app/src/test/java/com/android/shelflife/model/foodFacts/OpenFoodFactsRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.android.shelflife.model.foodFacts
 
+import com.android.shelfLife.model.foodFacts.FoodFacts
 import com.android.shelfLife.model.foodFacts.FoodSearchInput
 import com.android.shelfLife.model.foodFacts.OpenFoodFactsRepository
 import java.io.IOException
@@ -216,6 +217,7 @@ class OpenFoodFactsRepositoryTest {
                 {
                   "product_name": "Banana",
                   "code": "111111111",
+                  "image_url": "https://images.openfoodfacts.org/images/products/073/762/806/4502/front_en.6.400.jpg",
                   "nutriments": {
                     "energy-kcal_100g": 89,
                     "fat_100g": 0.3,
@@ -246,6 +248,9 @@ class OpenFoodFactsRepositoryTest {
     assertEquals(2, foodFactsList.size)
     assertEquals("Banana", foodFactsList[0].name)
     assertEquals("Apple", foodFactsList[1].name)
+    assertEquals("https://images.openfoodfacts.org/images/products/073/762/806/4502/front_en.6.400.jpg", foodFactsList[0].imageUrl)
+    //should expect default image constant
+    assertEquals(FoodFacts.DEFAULT_IMAGE_URL, foodFactsList[1].imageUrl)
     assertEquals(89, foodFactsList[0].nutritionFacts.energyKcal)
     assertEquals(52, foodFactsList[1].nutritionFacts.energyKcal)
   }

--- a/app/src/test/java/com/android/shelflife/model/foodFacts/OpenFoodFactsRepositoryTest.kt
+++ b/app/src/test/java/com/android/shelflife/model/foodFacts/OpenFoodFactsRepositoryTest.kt
@@ -247,8 +247,10 @@ class OpenFoodFactsRepositoryTest {
     assertEquals(2, foodFactsList.size)
     assertEquals("Banana", foodFactsList[0].name)
     assertEquals("Apple", foodFactsList[1].name)
-    assertEquals("https://images.openfoodfacts.org/images/products/073/762/806/4502/front_en.6.400.jpg", foodFactsList[0].imageUrl)
-    //should expect default image constant
+    assertEquals(
+        "https://images.openfoodfacts.org/images/products/073/762/806/4502/front_en.6.400.jpg",
+        foodFactsList[0].imageUrl)
+    // should expect default image constant
     assertEquals(FoodFacts.DEFAULT_IMAGE_URL, foodFactsList[1].imageUrl)
     assertEquals(89, foodFactsList[0].nutritionFacts.energyKcal)
     assertEquals(52, foodFactsList[1].nutritionFacts.energyKcal)


### PR DESCRIPTION
# PR: Feat/Add `imageUrl` handling to FoodFacts

## **Summary**

This PR introduces a refactor in the `FoodFacts` data class and enhances the `OpenFoodFactsRepository` to also handle the `imageUrl` property when extracting JSON product details from OpenFoodFacts.

## **Changes**

- **Refactor (`FoodFacts` Data Class)**
  - Introduced a **default image URL constant** for `imageUrl` in `FoodFacts`, it is placed in a companion object
  - `imageUrl` will default to this blank placeholder image

- **Enhancement (`extractFoodFactsFromJson` function)**
  - Updated the `extractFoodFactsFromJson` function inside `OpenFoodFactsRepository` function to extract the image Url or else use the default FoodFacts placeholder

## **Tests**
  - **(`OpenFoodFactsRepositoryTest`)** Enhanced existing tests to validate that `imageUrl` is correctly sent back if it exists, and defaults to the placeholder when invalid


## **Next steps**
- The OpenFoodFacts API sends back multiple images of multiple sizes. In the future we should store these multiple images, to adapt our UI to the viewport, and to optimize when we use smaller images (e.g we do not need large images for food icons)
 