### PR TITLE
fix: fix back button behavior

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/navigation/HouseHoldSelectionDrawer.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/navigation/HouseHoldSelectionDrawer.kt
@@ -1,5 +1,6 @@
 package com.android.shelfLife.ui.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -49,6 +50,9 @@ fun HouseHoldSelectionDrawer(
       editMode = false
     }
   }
+
+  // Close drawer on back button press if it's open
+  BackHandler(enabled = drawerState.isOpen) { scope.launch { drawerState.close() } }
 
   ModalNavigationDrawer(
       modifier = Modifier.testTag("householdSelectionDrawer"),


### PR DESCRIPTION
This pull request includes updates to the `HouseHoldSelectionDrawer` to fix the back button behavior.

Fix for issue:
* [`app/src/main/java/com/android/shelfLife/ui/navigation/HouseHoldSelectionDrawer.kt`](diffhunk://#diff-b517ff55e3986078e2a33eaa4e3866b50a169c0e24de70f7733d6a478c2f091dR54-R56): Implemented `BackHandler` to close the drawer when the back button is pressed, if the drawer is open.