### PR TITLE
Feat/169 add images into individual food items

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
@@ -83,7 +83,6 @@ fun IndividualFoodItemScreen(
                   modifier =
                       Modifier.fillMaxWidth()
                           .padding(horizontal = 16.dp, vertical = 8.dp)
-                          .background(Color.White)
                           .aspectRatio(1f)
                           .clip(RoundedCornerShape(8.dp))
                           .testTag("IndividualFoodItemImage"),

--- a/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
@@ -77,16 +77,6 @@ fun IndividualFoodItemScreen(
                   fontSize = 24.sp,
                   fontWeight = FontWeight.Bold,
                   modifier = Modifier.padding(16.dp).testTag("IndividualFoodItemName"))
-
-              //              Image(
-              //                  painter = painterResource(id = R.drawable.minecraft_rottenflesh),
-              //                  contentDescription = "Image of ${foodItem!!.foodFacts.name}",
-              //                  modifier =
-              //                      Modifier.fillMaxWidth()
-              //                          .aspectRatio(1f)
-              //                          .clip(RoundedCornerShape(8.dp))
-              //                          .testTag("IndividualFoodItemImage"),
-              //                  contentScale = ContentScale.Crop)
               AsyncImage(
                   model = foodItem!!.foodFacts.imageUrl,
                   contentDescription = "Food Image",

--- a/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
@@ -1,6 +1,6 @@
 package com.android.shelfLife.ui.overview
 
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,13 +22,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.android.shelfLife.R
+import coil3.compose.AsyncImage
 import com.android.shelfLife.model.foodItem.ListFoodItemsViewModel
 import com.android.shelfLife.ui.navigation.BottomNavigationMenu
 import com.android.shelfLife.ui.navigation.LIST_TOP_LEVEL_DESTINATION
@@ -78,11 +78,22 @@ fun IndividualFoodItemScreen(
                   fontWeight = FontWeight.Bold,
                   modifier = Modifier.padding(16.dp).testTag("IndividualFoodItemName"))
 
-              Image(
-                  painter = painterResource(id = R.drawable.minecraft_rottenflesh),
-                  contentDescription = "Image of ${foodItem!!.foodFacts.name}",
+              //              Image(
+              //                  painter = painterResource(id = R.drawable.minecraft_rottenflesh),
+              //                  contentDescription = "Image of ${foodItem!!.foodFacts.name}",
+              //                  modifier =
+              //                      Modifier.fillMaxWidth()
+              //                          .aspectRatio(1f)
+              //                          .clip(RoundedCornerShape(8.dp))
+              //                          .testTag("IndividualFoodItemImage"),
+              //                  contentScale = ContentScale.Crop)
+              AsyncImage(
+                  model = foodItem!!.foodFacts.imageUrl,
+                  contentDescription = "Food Image",
                   modifier =
                       Modifier.fillMaxWidth()
+                          .padding(horizontal = 16.dp, vertical = 8.dp)
+                          .background(Color.White)
                           .aspectRatio(1f)
                           .clip(RoundedCornerShape(8.dp))
                           .testTag("IndividualFoodItemImage"),

--- a/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
@@ -35,7 +35,6 @@ fun FoodItemDetails(foodItem: FoodItem) {
       modifier =
           Modifier.fillMaxWidth()
               .padding(horizontal = 16.dp, vertical = 8.dp)
-              .background(Color.White)
               .testTag("foodItemDetailsCard")) {
         Column(modifier = Modifier.padding(16.dp)) {
           FoodItemDetailText(


### PR DESCRIPTION
This pull request includes several changes to the `IndividualFoodItem.kt` file to update the UI components and improve the handling of food item images. The most important changes include replacing the `Image` component with `AsyncImage`, adding background color to the image modifier, and updating the imports accordingly. This works in tadem with the issue #161 which added images to the overview screen. Issue #169 

UI Component Updates:

* Replaced the `Image` component with `AsyncImage` to load images asynchronously and updated the image source to use `foodItem!!.foodFacts.imageUrl`.
* Added a background color to the image modifier using `Modifier.background(Color.White)`.

Import Updates:

* Removed unused imports `Image` and `painterResource` and added `background` and `Color` imports. [[1]](diffhunk://#diff-af0abf1724c393382dbd691cd0b9b98ccf7ab6f2f71bfb71d33858eab52658deL3-R3) [[2]](diffhunk://#diff-af0abf1724c393382dbd691cd0b9b98ccf7ab6f2f71bfb71d33858eab52658deR25-R31)

This is an example of the new UI:
![image_2024-11-14_203835836](https://github.com/user-attachments/assets/b984efdc-163d-4344-9536-c37682356f25)

