### PR TITLE
feat(ci): add workflow to build and upload APK

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest  # You can use ubuntu-latest, but macOS is better for M1 chips
+    runs-on: ubuntu-latest
 
     steps:
       # Checkout the repository
@@ -37,24 +37,17 @@ jobs:
         run: |
           echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
 
-      # Give gradle permission
+      # Grant execute permission for gradlew
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
-
-      # Generate debug keystore
-      - name: Generate debug keystore
-        run: |
-          mkdir -p ~/.android/
-          keytool -genkey -v \
-            -keystore ~/.android/debug.keystore \
-            -storepass android -keypass android \
-            -alias androiddebugkey \
-            -dname "CN=Android Debug,O=Android,C=US" \
-            -keyalg RSA -keysize 2048 -validity 10000
 
       # Build and Copy APK
       - name: Build and Copy APK
         run: ./gradlew copyApks
+
+      # List APK files in releases directory
+      - name: List APK files
+        run: ls -l app/releases/
 
       # Upload the APK as an artifact
       - name: Upload APK

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -41,6 +41,17 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
+      # Generate debug keystore
+      - name: Generate debug keystore
+        run: |
+          mkdir -p ~/.android/
+          keytool -genkey -v \
+            -keystore ~/.android/debug.keystore \
+            -storepass android -keypass android \
+            -alias androiddebugkey \
+            -dname "CN=Android Debug,O=Android,C=US" \
+            -keyalg RSA -keysize 2048 -validity 10000
+
       # Build and Copy APK
       - name: Build and Copy APK
         run: ./gradlew copyApks

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -41,15 +41,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      # Build the APK
-      - name: Build with Gradle
-        run: ./gradlew assembleDebug
+      # Build and Copy APK
+      - name: Build and Copy APK
+        run: ./gradlew copyApks
 
       # Upload the APK as an artifact
       - name: Upload APK
         uses: actions/upload-artifact@v3
         with:
           name: app-debug.apk
-          path: ${project.layout.buildDirectory.get()}/releases/app-debug.apk
-
-
+          path: app/releases/*.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,16 @@ android {
         }
     }
 
+    signingConfigs {
+        // Use debug signing configuration for both debug and release builds
+        getByName("debug") {
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+            storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            storePassword = "android"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -56,12 +66,13 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("debug") // Use debug signing for release
         }
 
         debug {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 
@@ -186,6 +197,21 @@ tasks.named("ktfmtCheckMain") {
 
 tasks.named("ktfmtCheckTest") {
     dependsOn(tasks.named("ktfmtFormatTest"))
+}
+
+// Task to copy APKs to app/releases/
+tasks.register<Copy>("copyApks") {
+    // Ensure the APK is built before copying
+    dependsOn("assembleDebug") // Use "assembleRelease" for release builds, or both
+
+    from("$buildDir/outputs/apk/")
+    into("$projectDir/releases/")
+
+    include("**/*.apk")
+
+    doLast {
+        println("APKs copied to ${project.projectDir}/releases/")
+    }
 }
 
 // Dependencies

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,16 +49,6 @@ android {
         }
     }
 
-    signingConfigs {
-        // Use debug signing configuration for both debug and release builds
-        getByName("debug") {
-            keyAlias = "androiddebugkey"
-            keyPassword = "android"
-            storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
-            storePassword = "android"
-        }
-    }
-
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -66,13 +56,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("debug") // Use debug signing for release
         }
 
         debug {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
-            signingConfig = signingConfigs.getByName("debug")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -190,15 +190,28 @@ tasks.named("ktfmtCheckTest") {
 // Task to copy APKs to app/releases/
 tasks.register<Copy>("copyApks") {
     // Ensure the APK is built before copying
-    dependsOn("assembleDebug") // Use "assembleRelease" for release builds, or both
+    dependsOn("assembleDebug")
 
-    from("$buildDir/outputs/apk/")
-    into("$projectDir/releases/")
+    val sourceDir = "$buildDir/outputs/apk/debug/"
+    val destinationDir = "$projectDir/releases/"
 
-    include("**/*.apk")
+    from(sourceDir)
+    into(destinationDir)
+
+    include("*.apk")
+
+    doFirst {
+        println("Listing APK files in source directory: $sourceDir")
+        fileTree(sourceDir).forEach {
+            println("Found file: ${it.name}")
+        }
+    }
 
     doLast {
-        println("APKs copied to ${project.projectDir}/releases/")
+        println("APKs copied to $destinationDir")
+        fileTree(destinationDir).forEach {
+            println("Copied APK: ${it.name}")
+        }
     }
 }
 


### PR DESCRIPTION
# feat(ci): add workflow to build and upload APK

## Description
This PR introduces a GitHub Actions workflow to automate the process of building the Android APK and uploading it as an artifact. The following changes were made:

- Added a new workflow (`Build Android APK`) to:
  - Set up the JDK.
  - Cache Gradle dependencies for faster builds.
  - Decode `google-services.json` from a secret.
  - Build the APK using Gradle (`assembleDebug`).
  - Copy the generated APK to the `app/releases/` directory.
  - Upload the APK as an artifact for later use or distribution.
- Updated `build.gradle.kts` to include:
  - A new `copyApks` task to move APKs to `app/releases/` after build.
  - Signing configurations for debug builds.
- Adjusted `.gitignore` rules to ensure the `app/releases/` directory is not ignored.

---

## Why is this change needed?
This automation will:
- Reduce manual effort in building and retrieving APKs during development and testing.
- Ensure consistency in the build process.
- Allow the APK to be easily downloaded directly from the Actions artifacts.

---

## How to Test
1. Trigger the workflow manually from the GitHub Actions tab.
2. Verify the following:
   - The workflow completes successfully.
   - The APK is copied to the `app/releases/` directory.
   - The APK is uploaded as an artifact.
3. Check the artifact download from the Actions page.

---

## Checklist
- [x] Code builds successfully.
- [x] GitHub Actions workflow runs without errors.
- [x] APK artifact can be downloaded from the Actions page.
- [x] PR reviewed for code quality.

---

## Additional Notes
If any adjustments are needed to support other build variants (e.g., `release`), we can extend the workflow and Gradle tasks accordingly.