### PR TITLE
fix: image updates when edit food item

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/overview/EditFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/EditFoodItem.kt
@@ -285,7 +285,9 @@ fun EditFoodItemScreen(
                                 quantity =
                                     Quantity(
                                         amount.toDouble(), selectedFood.foodFacts.quantity.unit),
-                                category = selectedFood.foodFacts.category)
+                                category = selectedFood.foodFacts.category,
+                                imageUrl = selectedFood.foodFacts.imageUrl,
+                            )
 
                         val newFoodItem =
                             FoodItem(


### PR DESCRIPTION
Fixed small bug where image would dissapear when food item was updated. The bug involved the new food facts not taking the selected Item's image URL