### PR TITLE
chore: switch cancel and submit buttons around

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/camera/FoodInputContent.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/FoodInputContent.kt
@@ -225,6 +225,14 @@ fun FoodInputContent(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)) {
               Button(
+                  onClick = { onCancel() },
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor = MaterialTheme.colorScheme.secondary),
+                  modifier = Modifier.weight(1f).height(50.dp).testTag("cancelButton")) {
+                    Text(text = "Cancel", fontSize = 18.sp)
+                  }
+              Button(
                   onClick = {
                     val isExpireDateValid = expireDateError == null && expireDate.isNotEmpty()
                     val isOpenDateValid = openDateError == null
@@ -248,6 +256,8 @@ fun FoodInputContent(
                               expiryDate = expiryTimestamp,
                               openDate = openTimestamp,
                               buyDate = buyTimestamp)
+
+                      Toast.makeText(context, "Food item added", Toast.LENGTH_SHORT).show()
                       onSubmit(newFoodItem)
                     } else {
                       Toast.makeText(
@@ -259,15 +269,6 @@ fun FoodInputContent(
                   },
                   modifier = Modifier.weight(1f).height(50.dp).testTag("submitButton")) {
                     Text(text = "Submit", fontSize = 18.sp)
-                  }
-
-              Button(
-                  onClick = { onCancel() },
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = MaterialTheme.colorScheme.secondary),
-                  modifier = Modifier.weight(1f).height(50.dp).testTag("cancelButton")) {
-                    Text(text = "Cancel", fontSize = 18.sp)
                   }
             }
       }

--- a/app/src/main/java/com/android/shelfLife/ui/camera/Scanner.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/camera/Scanner.kt
@@ -164,11 +164,8 @@ fun BarcodeScannerScreen(
                     CameraPreviewView(
                         modifier = Modifier.fillMaxSize(),
                         onBarcodeScanned = { scannedBarcode ->
-                          Log.d("BarcodeScanner", "Scanned barcode: $scannedBarcode")
+                          Log.i("BarcodeScanner", "Scanned barcode: $scannedBarcode")
                           beep()
-                          Toast.makeText(
-                                  context, "Scanned barcode: $scannedBarcode", Toast.LENGTH_SHORT)
-                              .show()
                           barcodeScanned.value = scannedBarcode
                           isScanningState.value = false
                           searchInProgress.value = true
@@ -200,7 +197,7 @@ fun BarcodeScannerScreen(
           foodScanned.value = true
           coroutineScope.launch { sheetScaffoldState.bottomSheetState.expand() }
         } else {
-          Toast.makeText(context, "Food Not Found", Toast.LENGTH_SHORT).show()
+          Toast.makeText(context, "Food Not Found in Database", Toast.LENGTH_SHORT).show()
           navigationActions.navigateTo(Screen.ADD_FOOD)
         }
         // Reset states
@@ -209,7 +206,8 @@ fun BarcodeScannerScreen(
         foodFactsViewModel.resetSearchStatus()
       }
       is SearchStatus.Failure -> {
-        Toast.makeText(context, "Search failed", Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, "Search failed, check internet connection", Toast.LENGTH_SHORT)
+            .show()
         barcodeScanned.value = null
         searchInProgress.value = false
         foodFactsViewModel.resetSearchStatus()


### PR DESCRIPTION
# chore: switch cancel and submit buttons around  

---

### **Description**  
This PR improves UI and messaging in the app:  

1. **UI Updates**:  
   - Reordered "Cancel" and "Submit" buttons in `FoodInputContent` to follow standard conventions.  

2. **Toast Notifications**:  
   - **Added**: Success toast ("Food item added") on submission.  
   - **Removed**: Barcode scanned toast ("Scanned barcode: $scannedBarcode").  
   - **Updated**: Improved error messages for food search and connection issues.  

---

### **Changes**  
- `FoodInputContent.kt`:  
  - Reorganized buttons, added success toast.  
- `Scanner.kt`:  
  - Removed barcode toast, updated error messages.  

---

### **Testing**  
- Verified button reordering and toast notifications for:  
  - Successful submissions.  
  - Errors (e.g., "Food Not Found in Database").  

---

### **Related Issues**  
- Closes #193 (Add and delete relevant toasts)  