### PR TITLE
184 add strings from addrecipescreen to stringxml

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/recipes/addRecipe.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/recipes/addRecipe.kt
@@ -1,6 +1,7 @@
 package com.android.shelfLife.ui.recipes
 
 import android.annotation.SuppressLint
+import android.provider.Settings.Global.getString
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -39,10 +40,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContentProviderCompat.requireContext
+import com.android.shelfLife.R
 import com.android.shelfLife.model.foodFacts.FoodFacts
 import com.android.shelfLife.model.foodFacts.FoodUnit
 import com.android.shelfLife.model.foodFacts.Quantity
@@ -112,7 +116,7 @@ fun AddRecipeScreen(
             // Title of the screen: Recipe name
             title = {
               Text(
-                  text = "Add your own recipe",
+                  text = stringResource(R.string.title_of_AddRecipeScreen),
                   style =
                       MaterialTheme.typography.bodyLarge.copy(
                           fontSize = 24.sp, fontWeight = FontWeight.Bold))
@@ -127,9 +131,9 @@ fun AddRecipeScreen(
                 value = title,
                 onValueChange = {
                   title = it
-                  titleError = if (title.isEmpty()) "Incomplete title" else null
+                    titleError = if (title.isEmpty()) context.getString(R.string.error_message_title_of_recipe) else null // todo add the string.xlm
                 },
-                label = { Text("Recipe title") },
+                label = { Text(stringResource(R.string.title_of_recipe)) },
                 modifier =
                     Modifier.fillMaxWidth().padding(vertical = 10.dp).testTag("inputRecipeTitle"))
           }
@@ -143,9 +147,9 @@ fun AddRecipeScreen(
                 value = servings,
                 onValueChange = {
                   servings = it
-                  servingsError = if (servings.isEmpty()) "Incomplete serving number" else null
+                  servingsError = if (servings.isEmpty()) context.getString(R.string.error_message_servings) else null // todo add the string.xlm
                 },
-                label = { Text("Servings") },
+                label = { Text(stringResource(R.string.servings)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier =
                     Modifier.fillMaxWidth()
@@ -162,9 +166,9 @@ fun AddRecipeScreen(
                 value = time,
                 onValueChange = {
                   time = it
-                  timeError = if (time.isEmpty()) "Incomplete time" else null
+                  timeError = if (time.isEmpty()) context.getString(R.string.error_message_time) else null // todo add the string.xlm
                 },
-                label = { Text("Time in minutes") },
+                label = { Text(stringResource(R.string.time)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier =
                     Modifier.fillMaxWidth().padding(vertical = 10.dp).testTag("inputRecipeTime"))
@@ -176,7 +180,7 @@ fun AddRecipeScreen(
           // recipe Ingredients
           item {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-              Text(text = "Ingredients", modifier = Modifier.testTag("ingredientSection"))
+              Text(text = stringResource(R.string.ingredients), modifier = Modifier.testTag("ingredientSection"))
             }
           }
 
@@ -206,7 +210,7 @@ fun AddRecipeScreen(
           // recipe instructions
           item {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-              Text(text = "Instructions", modifier = Modifier.testTag("instructionSection"))
+              Text(text = stringResource(R.string.instructions), modifier = Modifier.testTag("instructionSection"))
             }
           }
 
@@ -243,7 +247,7 @@ fun AddRecipeScreen(
                       onClick = { navigationActions.goBack() },
                       modifier = Modifier.height(40.dp).testTag("cancelButton"),
                       colors = ButtonDefaults.buttonColors(containerColor = errorContainerDark)) {
-                        Text(text = "Cancel", fontSize = 18.sp)
+                        Text(text = stringResource(R.string.cancel_button), fontSize = 18.sp)
                       }
 
                   Spacer(Modifier.width(24.dp))
@@ -282,7 +286,7 @@ fun AddRecipeScreen(
                       modifier = Modifier.height(40.dp).testTag("addButton"),
                       colors =
                           ButtonDefaults.buttonColors(containerColor = primaryContainerLight)) {
-                        Text(text = "Add", fontSize = 18.sp, color = onSecondaryDark)
+                        Text(text = stringResource(R.string.add_button), fontSize = 18.sp, color = onSecondaryDark)
                       }
                 }
           }
@@ -325,15 +329,18 @@ fun InstructionItem(
     onInstructionChange: (String) -> Unit,
     onRemoveClick: () -> Unit
 ) {
-  var instructionError by remember { mutableStateOf<String?>(null) }
+    val context = LocalContext.current
+
+    var instructionError by remember { mutableStateOf<String?>(null) }
   Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
     OutlinedTextField(
         value = instruction,
         onValueChange = { newInstruction ->
           onInstructionChange(newInstruction)
-          instructionError = if (newInstruction.isEmpty()) "Incomplete instruction" else null
+          instructionError = if (newInstruction.isEmpty()) context.getString(R.string.error_message_instructions) else null // todo add the string.xlm
         },
-        label = { Text("Step ${index + 1}") },
+
+        label = { Text(stringResource(R.string.instruction_step, index+1)) },
         modifier = Modifier.weight(1f).testTag("inputRecipeInstruction"))
     IconButton(onClick = onRemoveClick, modifier = Modifier.testTag("deleteInstructionButton")) {
       Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete Step")
@@ -367,7 +374,7 @@ fun IngredientItem(index: Int, ingredient: Ingredient, onRemoveClick: () -> Unit
   Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
     // title of ingredient
     Text(
-        text = "Ingredient${index + 1} : ${ingredient.foodFacts.name}",
+        text = stringResource(R.string.ingredient_item, index+1),
         modifier = Modifier.testTag("ingredientItem"))
     // delete button
     IconButton(onClick = onRemoveClick, modifier = Modifier.testTag("deleteIngredientButton")) {
@@ -407,7 +414,7 @@ fun IngredientDialog(
 
   androidx.compose.material3.AlertDialog(
       onDismissRequest = onDismiss,
-      title = { Text("Add Ingredient") },
+      title = { Text(stringResource(R.string.add_ingredient)) },
       text = {
         Column(modifier = Modifier.testTag("addIngredientPopUp")) {
           // ingredient name
@@ -415,9 +422,9 @@ fun IngredientDialog(
               value = ingredientName,
               onValueChange = {
                 ingredientName = it
-                ingredientNameError = if (ingredientName.isEmpty()) "Incomplete name" else null
+                ingredientNameError = if (ingredientName.isEmpty()) context.getString(R.string.error_message_ingredient_name) else null // todo add the string.xlm
               },
-              label = { Text("Ingredient Name") },
+              label = { Text(stringResource(R.string.ingredient_name)) },
               modifier = Modifier.fillMaxWidth().testTag("inputIngredientName"))
           // error message if ingredient name is empty
           ErrorTextBox(ingredientNameError, "ingredientNameErrorMessage")
@@ -427,9 +434,9 @@ fun IngredientDialog(
               value = ingredientQuantity,
               onValueChange = {
                 ingredientQuantity = it
-                quantityError = if (ingredientQuantity.isEmpty()) "Incomplete quantity" else null
+                quantityError = if (ingredientQuantity.isEmpty()) context.getString(R.string.error_message_ingredient_quantity) else null // todo add the string.xlm
               },
-              label = { Text("Quantity") },
+              label = { Text(stringResource(R.string.ingredient_quantity)) },
               keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
               modifier = Modifier.fillMaxWidth().testTag("inputIngredientQuantity"))
 
@@ -492,7 +499,7 @@ fun IngredientDialog(
                 ButtonDefaults.buttonColors(
                     containerColor = primaryContainerLight,
                     contentColor = secondaryContainerDark)) {
-              Text("Add Ingredient")
+              Text(stringResource(R.string.add_ingredient))
             }
       },
       // Cancel button
@@ -501,7 +508,7 @@ fun IngredientDialog(
             onClick = onDismiss,
             modifier = Modifier.testTag("cancelIngredientButton"),
             colors = ButtonDefaults.buttonColors(containerColor = errorContainerDark)) {
-              Text("Cancel")
+              Text(stringResource(R.string.cancel_button))
             }
       })
 }

--- a/app/src/main/java/com/android/shelfLife/ui/recipes/addRecipe.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/recipes/addRecipe.kt
@@ -1,7 +1,6 @@
 package com.android.shelfLife.ui.recipes
 
 import android.annotation.SuppressLint
-import android.provider.Settings.Global.getString
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -45,7 +44,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContentProviderCompat.requireContext
 import com.android.shelfLife.R
 import com.android.shelfLife.model.foodFacts.FoodFacts
 import com.android.shelfLife.model.foodFacts.FoodUnit
@@ -131,7 +129,9 @@ fun AddRecipeScreen(
                 value = title,
                 onValueChange = {
                   title = it
-                    titleError = if (title.isEmpty()) context.getString(R.string.error_message_title_of_recipe) else null // todo add the string.xlm
+                  titleError =
+                      if (title.isEmpty()) context.getString(R.string.error_message_title_of_recipe)
+                      else null
                 },
                 label = { Text(stringResource(R.string.title_of_recipe)) },
                 modifier =
@@ -147,7 +147,9 @@ fun AddRecipeScreen(
                 value = servings,
                 onValueChange = {
                   servings = it
-                  servingsError = if (servings.isEmpty()) context.getString(R.string.error_message_servings) else null // todo add the string.xlm
+                  servingsError =
+                      if (servings.isEmpty()) context.getString(R.string.error_message_servings)
+                      else null
                 },
                 label = { Text(stringResource(R.string.servings)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -166,7 +168,8 @@ fun AddRecipeScreen(
                 value = time,
                 onValueChange = {
                   time = it
-                  timeError = if (time.isEmpty()) context.getString(R.string.error_message_time) else null // todo add the string.xlm
+                  timeError =
+                      if (time.isEmpty()) context.getString(R.string.error_message_time) else null
                 },
                 label = { Text(stringResource(R.string.time)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -180,7 +183,9 @@ fun AddRecipeScreen(
           // recipe Ingredients
           item {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-              Text(text = stringResource(R.string.ingredients), modifier = Modifier.testTag("ingredientSection"))
+              Text(
+                  text = stringResource(R.string.ingredients),
+                  modifier = Modifier.testTag("ingredientSection"))
             }
           }
 
@@ -210,7 +215,9 @@ fun AddRecipeScreen(
           // recipe instructions
           item {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-              Text(text = stringResource(R.string.instructions), modifier = Modifier.testTag("instructionSection"))
+              Text(
+                  text = stringResource(R.string.instructions),
+                  modifier = Modifier.testTag("instructionSection"))
             }
           }
 
@@ -286,7 +293,10 @@ fun AddRecipeScreen(
                       modifier = Modifier.height(40.dp).testTag("addButton"),
                       colors =
                           ButtonDefaults.buttonColors(containerColor = primaryContainerLight)) {
-                        Text(text = stringResource(R.string.add_button), fontSize = 18.sp, color = onSecondaryDark)
+                        Text(
+                            text = stringResource(R.string.add_button),
+                            fontSize = 18.sp,
+                            color = onSecondaryDark)
                       }
                 }
           }
@@ -329,18 +339,19 @@ fun InstructionItem(
     onInstructionChange: (String) -> Unit,
     onRemoveClick: () -> Unit
 ) {
-    val context = LocalContext.current
+  val context = LocalContext.current
 
-    var instructionError by remember { mutableStateOf<String?>(null) }
+  var instructionError by remember { mutableStateOf<String?>(null) }
   Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
     OutlinedTextField(
         value = instruction,
         onValueChange = { newInstruction ->
           onInstructionChange(newInstruction)
-          instructionError = if (newInstruction.isEmpty()) context.getString(R.string.error_message_instructions) else null // todo add the string.xlm
+          instructionError =
+              if (newInstruction.isEmpty()) context.getString(R.string.error_message_instructions)
+              else null
         },
-
-        label = { Text(stringResource(R.string.instruction_step, index+1)) },
+        label = { Text(stringResource(R.string.instruction_step, index + 1)) },
         modifier = Modifier.weight(1f).testTag("inputRecipeInstruction"))
     IconButton(onClick = onRemoveClick, modifier = Modifier.testTag("deleteInstructionButton")) {
       Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete Step")
@@ -374,7 +385,7 @@ fun IngredientItem(index: Int, ingredient: Ingredient, onRemoveClick: () -> Unit
   Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
     // title of ingredient
     Text(
-        text = stringResource(R.string.ingredient_item, index+1),
+        text = stringResource(R.string.ingredient_item, index + 1, ingredient.foodFacts.name),
         modifier = Modifier.testTag("ingredientItem"))
     // delete button
     IconButton(onClick = onRemoveClick, modifier = Modifier.testTag("deleteIngredientButton")) {
@@ -422,7 +433,10 @@ fun IngredientDialog(
               value = ingredientName,
               onValueChange = {
                 ingredientName = it
-                ingredientNameError = if (ingredientName.isEmpty()) context.getString(R.string.error_message_ingredient_name) else null // todo add the string.xlm
+                ingredientNameError =
+                    if (ingredientName.isEmpty())
+                        context.getString(R.string.error_message_ingredient_name)
+                    else null
               },
               label = { Text(stringResource(R.string.ingredient_name)) },
               modifier = Modifier.fillMaxWidth().testTag("inputIngredientName"))
@@ -434,7 +448,10 @@ fun IngredientDialog(
               value = ingredientQuantity,
               onValueChange = {
                 ingredientQuantity = it
-                quantityError = if (ingredientQuantity.isEmpty()) context.getString(R.string.error_message_ingredient_quantity) else null // todo add the string.xlm
+                quantityError =
+                    if (ingredientQuantity.isEmpty())
+                        context.getString(R.string.error_message_ingredient_quantity)
+                    else null
               },
               label = { Text(stringResource(R.string.ingredient_quantity)) },
               keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="instructions">Instructions</string>
     <string name="error_message_instructions">Incomplete instruction</string>
     <string name="instruction_step">Step %1$s</string>
-    <string name="ingredient_item">Ingredient%1$s</string>
+    <string name="ingredient_item">Ingredient%1$s : %2$s</string>
     <string name="ingredient_name">Ingredient Name</string>
     <string name="error_message_ingredient_name">Incomplete name</string>
     <string name="ingredient_quantity">Quantity</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,9 +41,6 @@
     <string name="error_message_ingredient_quantity">Incomplete quantity</string>
     <string name="add_ingredient">Add Ingredient</string>
 
-    context.getString(R.string.error_message_instructions)
-
-
     <string name="cancel_button">Cancel</string>
     <string name="add_button">Add</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,29 @@
     <string name="food_item_quantity_label">Quantity: %1$s %2$s</string>
     <string name="food_item_no_expiry_date">No Expiry Date</string>
     <string name="food_item_not_opened">Not Opened</string>
+
+    <string name="title_of_AddRecipeScreen">Add your own recipe</string>
+    <string name="title_of_recipe">Recipe title</string>
+    <string name="error_message_title_of_recipe">Incomplete title</string>
+    <string name="servings">Servings</string>
+    <string name="error_message_servings">Incomplete serving number</string>
+    <string name="time">Time in minutes</string>
+    <string name="error_message_time">Incomplete time</string>
+    <string name="ingredients">Ingredients</string>
+    <string name="instructions">Instructions</string>
+    <string name="error_message_instructions">Incomplete instruction</string>
+    <string name="instruction_step">Step %1$s</string>
+    <string name="ingredient_item">Ingredient%1$s</string>
+    <string name="ingredient_name">Ingredient Name</string>
+    <string name="error_message_ingredient_name">Incomplete name</string>
+    <string name="ingredient_quantity">Quantity</string>
+    <string name="error_message_ingredient_quantity">Incomplete quantity</string>
+    <string name="add_ingredient">Add Ingredient</string>
+
+    context.getString(R.string.error_message_instructions)
+
+
+    <string name="cancel_button">Cancel</string>
+    <string name="add_button">Add</string>
+
 </resources>


### PR DESCRIPTION
### **Description**

In this PR, I move the strings from addRecipeScreen to string.xlm.

### **Key Changes**
1. **addRecipe.kt**:
i. replace the strings for their counterpart inside string.xlm
ii. if it was just a sting (ex: "Add Recipe") I will use the format 
`stringResource(R.string.title_of_AddRecipeScreen)`
iii. if it is an error message (ex: "Incomplete title") I will use the format `context.getString(R.string.error_message_title_of_recipe)` 

2. **strings.xlm**:
i. added all of the strings form addRecipeScreen

> I have added the string for the add and cancel buttons at the end. They are there because they will be used in other classes

### **Modified Files**
- **addRecipe.kt**
-  **strings.xlm**

There is no need for tests