### PR TITLE
Feat/183 improve creation screen UI

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -55,3 +55,7 @@ jobs:
         with:
           name: app-debug.apk
           path: app/releases/*.apk
+
+      # Get SHA1 of APK
+      - name: Get SHA1 of APK
+        run: ./gradlew signingReport

--- a/app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt
@@ -261,6 +261,7 @@ class EndToEndM2Test {
     composeTestRule.onNodeWithTag("HouseHoldCreationScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("HouseHoldNameTextField").performTextClearance()
     composeTestRule.onNodeWithTag("HouseHoldNameTextField").performTextInput("My House Rocks")
+    composeTestRule.onNodeWithTag("AddEmailFab").performClick()
     composeTestRule.onNodeWithTag("EmailInputField").performTextClearance()
     composeTestRule.onNodeWithTag("EmailInputField").performTextInput("dogwaterson@gmail.com")
     composeTestRule.onNodeWithTag("ConfirmButton").performClick()

--- a/app/src/androidTest/java/com/android/shelflife/ui/overview/HouseHoldCreationScreenTest.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/overview/HouseHoldCreationScreenTest.kt
@@ -2,6 +2,7 @@ package com.android.shelflife.ui.overview
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -136,7 +137,7 @@ class HouseHoldCreationScreenTest {
           navigationActions = navigationActions, householdViewModel = householdViewModel)
     }
     composeTestRule.onNodeWithTag("DeleteButton").performClick()
-    composeTestRule.onNodeWithTag("ConfirmDeleteButton").performClick()
+    composeTestRule.onNodeWithTag("confirmDeleteHouseholdButton").performClick()
     verify(houseHoldRepository).deleteHouseholdById(any(), any(), any())
   }
 
@@ -148,7 +149,7 @@ class HouseHoldCreationScreenTest {
           navigationActions = navigationActions, householdViewModel = householdViewModel)
     }
     composeTestRule.onNodeWithTag("DeleteButton").performClick()
-    composeTestRule.onNodeWithTag("CancelDeleteButton").performClick()
+    composeTestRule.onNodeWithTag("cancelDeleteHouseholdButton").performClick()
     composeTestRule.onNodeWithTag("DeleteConfirmationDialog").assertDoesNotExist()
   }
 
@@ -160,6 +161,7 @@ class HouseHoldCreationScreenTest {
           navigationActions = navigationActions, householdViewModel = householdViewModel)
     }
     val email = "test@example.com"
+    composeTestRule.onNodeWithTag("AddEmailFab").performClick()
     composeTestRule.onNodeWithTag("EmailInputField").performTextInput(email)
     composeTestRule.onNodeWithTag("AddEmailButton").performClick()
 
@@ -167,15 +169,16 @@ class HouseHoldCreationScreenTest {
   }
 
   @Test
-  fun addingEmailAddsNewTextBox() {
+  fun addingEmailDoesNotDisplayNewTextBox() {
     householdViewModel.selectHouseholdToEdit(null)
     composeTestRule.setContent {
       HouseHoldCreationScreen(
           navigationActions = navigationActions, householdViewModel = householdViewModel)
     }
     val email = "example@example.com"
+    composeTestRule.onNodeWithTag("AddEmailFab").performClick()
     composeTestRule.onNodeWithTag("EmailInputField").performTextInput(email)
     composeTestRule.onNodeWithTag("AddEmailButton").performClick()
-    composeTestRule.onNodeWithTag("EmailInputField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("EmailInputField").assertIsNotDisplayed()
   }
 }

--- a/app/src/main/java/com/android/shelfLife/model/creationScreen/CreationScreenViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/creationScreen/CreationScreenViewModel.kt
@@ -1,0 +1,23 @@
+package com.android.shelfLife.model.creationScreen
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CreationScreenViewModel(emailList: Set<String>) : ViewModel() {
+  private val _emailList = MutableStateFlow<Set<String>>(emptySet())
+  val emailList: StateFlow<Set<String>> = _emailList.asStateFlow()
+
+  init {
+    _emailList.value = emailList
+  }
+
+  fun addEmail(email: String) {
+    _emailList.value += email
+  }
+
+  fun removeEmail(email: String) {
+    _emailList.value -= email
+  }
+}

--- a/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
@@ -186,7 +186,7 @@ class HouseholdViewModel(
     _households.value
         .find { it.uid == householdId }
         ?.let { _households.value = _households.value.minus(it) }
-    if (householdId == _selectedHousehold.value!!.uid) {
+    if (_selectedHousehold.value == null || householdId == _selectedHousehold.value!!.uid) {
       // If the deleted household was selected, deselect it
       selectHousehold(_households.value.firstOrNull())
     }

--- a/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
@@ -127,6 +127,7 @@ class HouseholdViewModel(
             },
             onFailure = { exception ->
               Log.e("HouseholdViewModel", "Error adding household: $exception")
+              loadHouseholds()
             })
       }
     } else {

--- a/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
@@ -121,7 +121,10 @@ class HouseholdViewModel(
 
         repository.addHousehold(
             householdWithMembers,
-            onSuccess = { Log.d("HouseholdViewModel", "Household added successfully") },
+            onSuccess = {
+              Log.d("HouseholdViewModel", "Household added successfully")
+              loadHouseholds()
+            },
             onFailure = { exception ->
               Log.e("HouseholdViewModel", "Error adding household: $exception")
             })
@@ -129,7 +132,6 @@ class HouseholdViewModel(
     } else {
       Log.e("HouseholdViewModel", "User not logged in")
     }
-    loadHouseholds()
   }
 
   /**

--- a/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
@@ -61,6 +61,27 @@ class HouseholdViewModel(
           finishedLoading.value = true
         })
   }
+
+  private fun updateViewModelStateWithHousehold(household: HouseHold) {
+    val currentHouseholds = _households.value
+    val existingHousehold = currentHouseholds.find { it.uid == household.uid }
+
+    // Update the households list
+    _households.value =
+        if (existingHousehold == null) {
+          currentHouseholds.plus(household)
+        } else {
+          currentHouseholds.minus(existingHousehold).plus(household)
+        }
+
+    // Update the selected household if necessary
+    if (_selectedHousehold.value == null) {
+      selectHousehold(_households.value.firstOrNull()) // Default to the first household
+    } else {
+      updateSelectedHousehold()
+    }
+  }
+
   /**
    * Updates the selected household with the latest data from the list of households using the uid,
    * we may need to add another uid than the name.
@@ -121,14 +142,13 @@ class HouseholdViewModel(
 
         repository.addHousehold(
             householdWithMembers,
-            onSuccess = {
-              Log.d("HouseholdViewModel", "Household added successfully")
-              loadHouseholds()
-            },
+            onSuccess = { Log.d("HouseholdViewModel", "Household added successfully") },
             onFailure = { exception ->
               Log.e("HouseholdViewModel", "Error adding household: $exception")
-              loadHouseholds()
             })
+        // Update the list of households locally, this saves resources and ensures that
+        // the UI is updated
+        updateViewModelStateWithHousehold(householdWithMembers)
       }
     } else {
       Log.e("HouseholdViewModel", "User not logged in")
@@ -147,7 +167,7 @@ class HouseholdViewModel(
         onFailure = { exception ->
           Log.e("HouseholdViewModel", "Error updating household: $exception")
         })
-    loadHouseholds()
+    updateViewModelStateWithHousehold(household)
   }
 
   /**
@@ -162,7 +182,14 @@ class HouseholdViewModel(
         onFailure = { exception ->
           Log.e("HouseholdViewModel", "Error deleting household: $exception")
         })
-    loadHouseholds()
+    // Delete household from the list of households
+    _households.value
+        .find { it.uid == householdId }
+        ?.let { _households.value = _households.value.minus(it) }
+    if (householdId == _selectedHousehold.value!!.uid) {
+      // If the deleted household was selected, deselect it
+      selectHousehold(_households.value.firstOrNull())
+    }
   }
 
   // TODO this is a bad way to update the food items, we need a plan to separate the food items from

--- a/app/src/main/java/com/android/shelfLife/ui/navigation/HouseHoldSelectionDrawer.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/navigation/HouseHoldSelectionDrawer.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -20,7 +19,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -32,8 +30,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.android.shelfLife.model.household.HouseHold
 import com.android.shelfLife.model.household.HouseholdViewModel
+import com.android.shelfLife.ui.utils.DeletionConfirmationPopUp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -45,13 +43,12 @@ fun HouseHoldSelectionDrawer(
     householdViewModel: HouseholdViewModel,
     content: @Composable () -> Unit
 ) {
-  val userHouseholds = householdViewModel.households.collectAsState().value
+  val userHouseholds by householdViewModel.households.collectAsState()
   val selectedHousehold by householdViewModel.selectedHousehold.collectAsState()
   var editMode by remember { mutableStateOf(false) }
 
   // State for confirmation dialog
   var showDeleteDialog by remember { mutableStateOf(false) }
-  var householdToDelete by remember { mutableStateOf<HouseHold?>(null) }
 
   // Disable edit mode when the drawer is closed
   LaunchedEffect(drawerState.isClosed) {
@@ -97,7 +94,7 @@ fun HouseHoldSelectionDrawer(
                       navigationActions.navigateTo(Screen.HOUSEHOLD_CREATION)
                     },
                     onHouseholdDeleteSelected = { household ->
-                      householdToDelete = household
+                      householdViewModel.selectHouseholdToEdit(household)
                       showDeleteDialog = true
                     },
                     modifier = Modifier.testTag("householdElement_$index"),
@@ -136,35 +133,9 @@ fun HouseHoldSelectionDrawer(
       content = content)
 
   // Confirmation Dialog for Deletion
-  if (showDeleteDialog && householdToDelete != null) {
-    AlertDialog(
-        onDismissRequest = { showDeleteDialog = false },
-        title = { Text("Delete Household") },
-        text = { Text("Are you sure you want to delete '${householdToDelete!!.name}'?") },
-        confirmButton = {
-          TextButton(
-              onClick = {
-                householdViewModel.deleteHouseholdById(householdToDelete!!.uid)
-                if (householdToDelete == selectedHousehold) {
-                  // If the deleted household was selected, deselect it
-                  householdViewModel.selectHousehold(null)
-                }
-                householdToDelete = null
-                showDeleteDialog = false
-              },
-              modifier = Modifier.testTag("confirmDeleteHouseholdButton")) {
-                Text("Delete", color = MaterialTheme.colorScheme.error)
-              }
-        },
-        dismissButton = {
-          TextButton(
-              onClick = {
-                householdToDelete = null
-                showDeleteDialog = false
-              },
-              modifier = Modifier.testTag("cancelDeleteHouseholdButton")) {
-                Text("Cancel")
-              }
-        })
-  }
+  DeletionConfirmationPopUp(
+      showDeleteDialog = showDeleteDialog,
+      onDismiss = { showDeleteDialog = false },
+      onConfirm = { showDeleteDialog = false },
+      householdViewModel = householdViewModel)
 }

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -70,6 +71,16 @@ fun HouseHoldCreationScreen(
   // Fetch member emails when the screen is opened for editing
   LaunchedEffect(householdToEdit) {
     householdToEdit?.let { householdViewModel.selectHouseholdToEdit(it) }
+  }
+
+  // Function to add email card to the list and scroll to the bottom
+  fun addEmailCard() {
+    if (emailInput.isNotBlank()) {
+      memberEmailList.add(emailInput.trim())
+      emailInput = ""
+    }
+    showEmailTextField = false
+    coroutineScope.launch { columnScrollState.scrollTo(columnScrollState.maxValue) }
   }
 
   Scaffold(
@@ -178,18 +189,10 @@ fun HouseHoldCreationScreen(
                             label = { Text("Friend's Email") },
                             placeholder = { Text("Enter email") },
                             singleLine = true,
+                            keyboardActions = KeyboardActions(onDone = { addEmailCard() }),
                             modifier = Modifier.weight(1f).testTag("EmailInputField"))
                         IconButton(
-                            onClick = {
-                              if (emailInput.isNotBlank()) {
-                                memberEmailList.add(emailInput.trim())
-                                emailInput = ""
-                              }
-                              showEmailTextField = false
-                              coroutineScope.launch {
-                                columnScrollState.scrollTo(columnScrollState.maxValue)
-                              }
-                            },
+                            onClick = { addEmailCard() },
                             modifier = Modifier.testTag("AddEmailButton")) {
                               Icon(
                                   imageVector = Icons.Default.Check,

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -82,7 +82,6 @@ fun HouseHoldCreationScreen(
   // Function to add email card to the list and scroll to the bottom
   fun addEmailCard() {
     if (emailInput.isNotBlank() && emailInput.trim() !in memberEmailList.value) {
-      // TODO check if email is valid
       creationScreenViewModel.addEmail(emailInput.trim())
       emailInput = ""
     }

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -64,6 +64,7 @@ fun HouseHoldCreationScreen(
   // Initialize memberEmailList when memberEmails are fetched
   LaunchedEffect(memberEmails) { memberEmailList.addAll(memberEmails.values) }
 
+  // Scroll to the bottom and focus on the email input field when the email input field is shown
   LaunchedEffect(showEmailTextField) {
     if (showEmailTextField) {
       coroutineScope.launch { columnScrollState.animateScrollTo(columnScrollState.maxValue) }

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -45,15 +45,15 @@ fun HouseHoldCreationScreen(
   val householdToEdit by householdViewModel.householdToEdit.collectAsState()
   val memberEmails by householdViewModel.memberEmails.collectAsState()
 
-  var isError by remember { mutableStateOf(false) }
+  var isError by rememberSaveable { mutableStateOf(false) }
   var houseHoldName by rememberSaveable { mutableStateOf(householdToEdit?.name ?: "") }
 
-  var showConfirmationDialog by remember { mutableStateOf(false) }
+  var showConfirmationDialog by rememberSaveable { mutableStateOf(false) }
 
   // Mutable state list to hold member emails
-  val memberEmailList = remember { mutableStateListOf<String>() }
+  val memberEmailList = rememberSaveable { mutableStateListOf<String>() }
   var emailInput by rememberSaveable { mutableStateOf("") }
-  var showEmailTextField by remember { mutableStateOf(false) }
+  var showEmailTextField by rememberSaveable { mutableStateOf(false) }
 
   val columnScrollState = rememberScrollState()
 

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.shelfLife.model.household.HouseholdViewModel
 import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.utils.DeletionConfirmationPopUp
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -54,7 +55,7 @@ fun HouseHoldCreationScreen(
   var emailInput by rememberSaveable { mutableStateOf("") }
   var showEmailTextField by remember { mutableStateOf(false) }
 
-  var columnScrollState = rememberScrollState()
+  val columnScrollState = rememberScrollState()
 
   // Initialize memberEmailList when memberEmails are fetched
   LaunchedEffect(memberEmails) {
@@ -76,6 +77,7 @@ fun HouseHoldCreationScreen(
   // Function to add email card to the list and scroll to the bottom
   fun addEmailCard() {
     if (emailInput.isNotBlank()) {
+      // TODO check if email is valid
       memberEmailList.add(emailInput.trim())
       emailInput = ""
     }
@@ -280,34 +282,15 @@ fun HouseHoldCreationScreen(
                     }
                   }
 
-              if (showConfirmationDialog) {
-                AlertDialog(
-                    modifier = Modifier.testTag("DeleteConfirmationDialog"),
-                    onDismissRequest = { showConfirmationDialog = false },
-                    title = { Text("Delete household") },
-                    text = { Text("Are you sure?") },
-                    confirmButton = {
-                      TextButton(
-                          modifier = Modifier.testTag("ConfirmDeleteButton"),
-                          onClick = {
-                            if (householdToEdit != null) {
-                              householdViewModel.deleteHouseholdById(householdToEdit!!.uid)
-                            }
-                            navigationActions.goBack()
-                            showConfirmationDialog = false
-                          }) {
-                            Text("Confirm")
-                          }
-                    },
-                    dismissButton = {
-                      TextButton(
-                          modifier = Modifier.testTag("CancelDeleteButton"),
-                          onClick = { showConfirmationDialog = false }) {
-                            Text("Cancel")
-                          }
-                    },
-                )
-              }
+              // Confirmation Dialog for Deletion
+              DeletionConfirmationPopUp(
+                  showDeleteDialog = showConfirmationDialog,
+                  onDismiss = { showConfirmationDialog = false },
+                  onConfirm = {
+                    navigationActions.goBack()
+                    showConfirmationDialog = false
+                  },
+                  householdViewModel = householdViewModel)
             }
       }
 }

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.shelfLife.model.creationScreen.CreationScreenViewModel
 import com.android.shelfLife.model.household.HouseholdViewModel
 import com.android.shelfLife.ui.navigation.NavigationActions
 import com.android.shelfLife.ui.utils.DeletionConfirmationPopUp
@@ -43,9 +45,12 @@ fun HouseHoldCreationScreen(
     navigationActions: NavigationActions,
     householdViewModel: HouseholdViewModel,
 ) {
+  val memberEmails by householdViewModel.memberEmails.collectAsState()
+  val creationScreenViewModel: CreationScreenViewModel = viewModel {
+    CreationScreenViewModel(memberEmails.values.toSet())
+  }
   val coroutineScope = rememberCoroutineScope()
   val householdToEdit by householdViewModel.householdToEdit.collectAsState()
-  val memberEmails by householdViewModel.memberEmails.collectAsState()
 
   var isError by rememberSaveable { mutableStateOf(false) }
   var houseHoldName by rememberSaveable { mutableStateOf(householdToEdit?.name ?: "") }
@@ -53,16 +58,13 @@ fun HouseHoldCreationScreen(
   var showConfirmationDialog by rememberSaveable { mutableStateOf(false) }
 
   // Mutable state list to hold member emails
-  val memberEmailList = rememberSaveable { mutableSetOf<String>() }
+  val memberEmailList = creationScreenViewModel.emailList.collectAsState()
   var emailInput by rememberSaveable { mutableStateOf("") }
   var showEmailTextField by rememberSaveable { mutableStateOf(false) }
 
   val columnScrollState = rememberScrollState()
 
   val focusRequester = remember { FocusRequester() }
-
-  // Initialize memberEmailList when memberEmails are fetched
-  LaunchedEffect(memberEmails) { memberEmailList.addAll(memberEmails.values) }
 
   // Scroll to the bottom and focus on the email input field when the email input field is shown
   LaunchedEffect(showEmailTextField) {
@@ -79,9 +81,9 @@ fun HouseHoldCreationScreen(
 
   // Function to add email card to the list and scroll to the bottom
   fun addEmailCard() {
-    if (emailInput.isNotBlank()) {
+    if (emailInput.isNotBlank() && emailInput.trim() !in memberEmailList.value) {
       // TODO check if email is valid
-      memberEmailList.add(emailInput.trim())
+      creationScreenViewModel.addEmail(emailInput.trim())
       emailInput = ""
     }
     showEmailTextField = false
@@ -155,7 +157,7 @@ fun HouseHoldCreationScreen(
                           .verticalScroll(columnScrollState)
                           .weight(1f),
               ) {
-                memberEmailList.forEach { email ->
+                memberEmailList.value.forEach { email ->
                   ElevatedCard(
                       elevation = CardDefaults.elevatedCardElevation(defaultElevation = 8.dp),
                       modifier =
@@ -172,7 +174,7 @@ fun HouseHoldCreationScreen(
                                   style = TextStyle(fontSize = 16.sp),
                                   modifier = Modifier.weight(1f))
                               IconButton(
-                                  onClick = { memberEmailList.remove(email) },
+                                  onClick = { creationScreenViewModel.removeEmail(email) },
                                   modifier = Modifier.testTag("RemoveEmailButton")) {
                                     Icon(
                                         imageVector = Icons.Default.Delete,
@@ -237,27 +239,28 @@ fun HouseHoldCreationScreen(
                             isError = true
                           } else {
                             coroutineScope.launch {
-                              householdViewModel.getUserIdsByEmails(memberEmailList.toList()) {
-                                  emailToUid ->
-                                val missingEmails =
-                                    memberEmailList.filter { it !in emailToUid.keys }
-                                if (missingEmails.isNotEmpty()) {
-                                  Log.w(
-                                      "HouseHoldCreationScreen", "Emails not found: $missingEmails")
-                                }
-                                val memberUids = emailToUid.values.toMutableList()
+                              householdViewModel.getUserIdsByEmails(
+                                  memberEmailList.value.toList()) { emailToUid ->
+                                    val missingEmails =
+                                        memberEmailList.value.filter { it !in emailToUid.keys }
+                                    if (missingEmails.isNotEmpty()) {
+                                      Log.w(
+                                          "HouseHoldCreationScreen",
+                                          "Emails not found: $missingEmails")
+                                    }
+                                    val memberUids = emailToUid.values.toMutableList()
 
-                                if (householdToEdit != null) {
-                                  val updatedHouseHold =
-                                      householdToEdit!!.copy(
-                                          name = houseHoldName, members = memberUids)
-                                  householdViewModel.updateHousehold(updatedHouseHold)
-                                } else {
-                                  householdViewModel.addNewHousehold(
-                                      houseHoldName, memberEmailList.toList())
-                                }
-                                navigationActions.goBack()
-                              }
+                                    if (householdToEdit != null) {
+                                      val updatedHouseHold =
+                                          householdToEdit!!.copy(
+                                              name = houseHoldName, members = memberUids)
+                                      householdViewModel.updateHousehold(updatedHouseHold)
+                                    } else {
+                                      householdViewModel.addNewHousehold(
+                                          houseHoldName, memberEmailList.value.toList())
+                                    }
+                                    navigationActions.goBack()
+                                  }
                             }
                           }
                         },

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -204,7 +204,7 @@ fun HouseHoldCreationScreen(
                 }
 
                 FloatingActionButton(
-                    modifier = Modifier.padding(top = 20.dp, bottom = 20.dp),
+                    modifier = Modifier.padding(top = 20.dp, bottom = 20.dp).testTag("AddEmailFab"),
                     onClick = { showEmailTextField = !showEmailTextField },
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                 ) {

--- a/app/src/main/java/com/android/shelfLife/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/Overview.kt
@@ -1,5 +1,6 @@
 package com.android.shelfLife.ui.overview
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,12 +48,14 @@ fun OverviewScreen(
     householdViewModel: HouseholdViewModel,
     listFoodItemsViewModel: ListFoodItemsViewModel
 ) {
-  val selectedHousehold = householdViewModel.selectedHousehold.collectAsState()
+  val selectedHousehold by householdViewModel.selectedHousehold.collectAsState()
   var searchQuery by remember { mutableStateOf("") }
-  val foodItems = listFoodItemsViewModel.foodItems.collectAsState()
-  val userHouseholds = householdViewModel.households.collectAsState().value
-  val householdViewModelIsLoaded = householdViewModel.finishedLoading.collectAsState().value
+  val foodItems by listFoodItemsViewModel.foodItems.collectAsState()
+  val userHouseholds by householdViewModel.households.collectAsState()
+  val householdViewModelIsLoaded by householdViewModel.finishedLoading.collectAsState()
   val selectedFilters = remember { mutableStateListOf<String>() }
+
+  Log.d("OverviewScreen", "Selected household: $selectedHousehold ${userHouseholds.size}")
 
   val drawerState = rememberDrawerState(DrawerValue.Closed)
   val scope = rememberCoroutineScope()
@@ -65,7 +68,7 @@ fun OverviewScreen(
       householdViewModel = householdViewModel,
       navigationActions = navigationActions) {
         val filteredFoodItems =
-            foodItems.value.filter { item ->
+            foodItems.filter { item ->
               item.foodFacts.name.contains(searchQuery, ignoreCase = true) &&
                   (selectedFilters.isEmpty() ||
                       selectedFilters.contains(item.foodFacts.category.name))
@@ -79,13 +82,13 @@ fun OverviewScreen(
           ) {
             CircularProgressIndicator()
           }
-        } else if (selectedHousehold.value == null && userHouseholds.isEmpty()) {
+        } else if (selectedHousehold == null && userHouseholds.isEmpty()) {
           FirstTimeWelcomeScreen(navigationActions, householdViewModel)
         } else {
           Scaffold(
               modifier = Modifier.testTag("overviewScreen"),
               topBar = {
-                selectedHousehold.value?.let {
+                selectedHousehold?.let {
                   TopNavigationBar(
                       houseHold = it,
                       onHamburgerClick = { scope.launch { drawerState.open() } },

--- a/app/src/main/java/com/android/shelfLife/ui/utils/DeletionConfirmationPopUp.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/DeletionConfirmationPopUp.kt
@@ -1,0 +1,50 @@
+package com.android.shelfLife.ui.utils
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.shelfLife.model.household.HouseholdViewModel
+
+@Composable
+fun DeletionConfirmationPopUp(
+    showDeleteDialog: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    householdViewModel: HouseholdViewModel
+) {
+  val householdToDelete = householdViewModel.householdToEdit.collectAsState().value
+  val selectedHousehold = householdViewModel.selectedHousehold.collectAsState().value
+
+  if (showDeleteDialog) {
+    AlertDialog(
+        onDismissRequest = { onDismiss() },
+        title = { Text("Delete Household") },
+        text = { Text("Are you sure you want to delete '${householdToDelete!!.name}'?") },
+        confirmButton = {
+          TextButton(
+              onClick = {
+                householdViewModel.deleteHouseholdById(householdToDelete!!.uid)
+                if (householdToDelete == selectedHousehold) {
+                  // If the deleted household was selected, deselect it
+                  householdViewModel.selectHousehold(null)
+                }
+                onConfirm()
+              },
+              modifier = Modifier.testTag("confirmDeleteHouseholdButton")) {
+                Text("Delete", color = MaterialTheme.colorScheme.error)
+              }
+        },
+        dismissButton = {
+          TextButton(
+              onClick = { onDismiss() },
+              modifier = Modifier.testTag("cancelDeleteHouseholdButton")) {
+                Text("Cancel")
+              }
+        })
+  }
+}

--- a/app/src/main/java/com/android/shelfLife/ui/utils/DeletionConfirmationPopUp.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/DeletionConfirmationPopUp.kt
@@ -30,10 +30,6 @@ fun DeletionConfirmationPopUp(
           TextButton(
               onClick = {
                 householdViewModel.deleteHouseholdById(householdToDelete!!.uid)
-                if (householdToDelete == selectedHousehold) {
-                  // If the deleted household was selected, deselect it
-                  householdViewModel.selectHousehold(null)
-                }
                 onConfirm()
               },
               modifier = Modifier.testTag("confirmDeleteHouseholdButton")) {

--- a/app/src/main/java/com/android/shelfLife/ui/utils/DeletionConfirmationPopUp.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/DeletionConfirmationPopUp.kt
@@ -25,6 +25,7 @@ fun DeletionConfirmationPopUp(
         onDismissRequest = { onDismiss() },
         title = { Text("Delete Household") },
         text = { Text("Are you sure you want to delete '${householdToDelete!!.name}'?") },
+        modifier = Modifier.testTag("DeleteConfirmationDialog"),
         confirmButton = {
           TextButton(
               onClick = {

--- a/app/src/test/java/com/android/shelflife/model/household/HouseHoldViewModelTest.kt
+++ b/app/src/test/java/com/android/shelflife/model/household/HouseHoldViewModelTest.kt
@@ -334,9 +334,6 @@ class HouseholdViewModelTest {
             foodItems = emptyList())
 
     assertEquals(expectedHousehold, householdCaptor.firstValue)
-
-    // Verify that loadHouseholds is called
-    verify(repository, atLeastOnce()).getHouseholds(any(), any())
   }
 
   @Test
@@ -378,9 +375,6 @@ class HouseholdViewModelTest {
 
     val expectedMembers = listOf(userUid) + friendUserIds.values
     assertEquals(expectedMembers.sorted(), householdCaptor.firstValue.members.sorted())
-
-    // Verify that loadHouseholds is called
-    verify(repository, atLeastOnce()).getHouseholds(any(), any())
   }
 
   @Test
@@ -422,10 +416,6 @@ class HouseholdViewModelTest {
 
     val expectedMembers = listOf(userUid) + friendUserIds.values
     assertEquals(expectedMembers.sorted(), householdCaptor.firstValue.members.sorted())
-
-    // Verify that loadHouseholds is called
-    verify(repository, atLeastOnce()).getHouseholds(any(), any())
-    // Optionally, check that a warning is logged about emails not found
   }
 
   @Test
@@ -458,10 +448,6 @@ class HouseholdViewModelTest {
 
     // Act
     householdViewModel.addNewHousehold(householdName, friendEmails)
-
-    // Assert
-    // Verify that loadHouseholds is called
-    verify(repository, atLeastOnce()).getHouseholds(any(), any())
     // Optionally, check that an error is logged with the exception
   }
 

--- a/app/src/test/java/com/android/shelflife/model/household/HouseHoldViewModelTest.kt
+++ b/app/src/test/java/com/android/shelflife/model/household/HouseHoldViewModelTest.kt
@@ -88,28 +88,6 @@ class HouseholdViewModelTest {
     firebaseAuthMock.close()
   }
 
-  // This test needs for the user to be logged in, no idea how to mock this
-  /*
-  @Test
-  fun `init should load households`() = runTest {
-    // Arrange
-    val households = listOf(HouseHold("1", "Household 1", emptyList(), emptyList()))
-
-    whenever(repository.getHouseholds(any(), any())).thenAnswer { invocation ->
-      val onSuccess = invocation.getArgument<(List<HouseHold>) -> Unit>(0)
-      onSuccess(households)
-      null
-    }
-    // Act
-    householdViewModel = HouseholdViewModel(repository, listFoodItemsViewModel)
-
-    // Assert
-    assertEquals(households, householdViewModel.households.value)
-    assertEquals(households.first(), householdViewModel.selectedHousehold.value)
-    verify(listFoodItemsViewModel).setFoodItems(households.first().foodItems)
-  }
-
-   */
   @Test
   fun `selectHousehold should update selected household and food items`() = runTest {
     // Arrange
@@ -139,35 +117,6 @@ class HouseholdViewModelTest {
     // Assert
     assertEquals(household, householdViewModel.selectedHousehold.value)
     verify(listFoodItemsViewModel).setFoodItems(household.foodItems)
-  }
-
-  @Test
-  fun `addNewHousehold should add household and reload households`() = runTest {
-    // Arrange
-    val householdName = "New Household"
-    val newUid = "uid"
-    val newHousehold = HouseHold(newUid, householdName, emptyList(), emptyList())
-
-    whenever(repository.getNewUid()).thenReturn(newUid)
-    whenever(repository.addHousehold(any(), any(), any())).thenAnswer { invocation ->
-      val onSuccess = invocation.getArgument<() -> Unit>(1)
-      onSuccess()
-      null
-    }
-    val households = listOf(newHousehold)
-    whenever(repository.getHouseholds(any(), any())).thenAnswer { invocation ->
-      val onSuccess = invocation.getArgument<(List<HouseHold>) -> Unit>(0)
-      onSuccess(households)
-      null
-    }
-
-    householdViewModel = HouseholdViewModel(repository, listFoodItemsViewModel)
-
-    // Act
-    householdViewModel.addNewHousehold(householdName)
-
-    // Assert
-    assertEquals(households, householdViewModel.households.value)
   }
 
   @Test
@@ -339,8 +288,6 @@ class HouseholdViewModelTest {
     // Assert
     // Verify that repository.addHousehold is not called
     verify(repository, never()).addHousehold(any(), any(), any())
-    // Verify that loadHouseholds is called
-    verify(repository).getHouseholds(any(), any())
     // Optionally, you can verify that an error is logged
   }
 

--- a/app/src/test/java/com/android/shelflife/model/household/HouseHoldViewModelTest.kt
+++ b/app/src/test/java/com/android/shelflife/model/household/HouseHoldViewModelTest.kt
@@ -36,7 +36,6 @@ import org.mockito.Mockito.mockStatic
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify


### PR DESCRIPTION
This pull request includes various updates to the `HouseholdViewModel` and related UI components to improve functionality and user experience. The most important changes include the addition of a new method to update the view model state, modifications to UI tests, and updates to the household creation and selection screens.

### Changes to `HouseholdViewModel`:
- Many operations (add, update and delete household) are now done localy instead of reloading the data from the database, this greatly improves efficiency and fixes many timing bugs

### Changes to `HouseHoldCreationScreen`:
- Changed many variables to rememberSaveable so that they survive screen rotations
- Reworked email adding and displaying. The user flow is now more intuitive.
- The email adress list is now scrollable

### Tests:
- Adapted the tests to work with the new UI and logic