### PR TITLE
Feat/187 add an option to delete food items

### DIFF
--- a/app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt
@@ -167,7 +167,9 @@ class EndToEndM2Test {
         }
         composable(Screen.INDIVIDUAL_FOOD_ITEM) {
           IndividualFoodItemScreen(
-              navigationActions = navigationActions, houseHoldViewModel = householdViewModel, foodItemViewModel = listFoodItemsViewModel)
+              navigationActions = navigationActions,
+              houseHoldViewModel = householdViewModel,
+              foodItemViewModel = listFoodItemsViewModel)
         }
         composable(Route.RECIPES) {
           RecipesScreen(navigationActions, listRecipesViewModel, householdViewModel)

--- a/app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt
@@ -167,7 +167,7 @@ class EndToEndM2Test {
         }
         composable(Screen.INDIVIDUAL_FOOD_ITEM) {
           IndividualFoodItemScreen(
-              navigationActions = navigationActions, foodItemViewModel = listFoodItemsViewModel)
+              navigationActions = navigationActions, houseHoldViewModel = householdViewModel, foodItemViewModel = listFoodItemsViewModel)
         }
         composable(Route.RECIPES) {
           RecipesScreen(navigationActions, listRecipesViewModel, householdViewModel)

--- a/app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt
@@ -80,7 +80,9 @@ class IndividualFoodItemScreenTest {
   fun individualFoodItemScreenDisplaysCorrectly() = runTest {
     composeTestRule.setContent {
       IndividualFoodItemScreen(
-          navigationActions = navigationActions, houseHoldViewModel = houseHoldViewModel, foodItemViewModel = foodItemViewModel)
+          navigationActions = navigationActions,
+          houseHoldViewModel = houseHoldViewModel,
+          foodItemViewModel = foodItemViewModel)
     }
 
     // Check if the screen displays the correct food item details
@@ -96,7 +98,9 @@ class IndividualFoodItemScreenTest {
 
     composeTestRule.setContent {
       IndividualFoodItemScreen(
-          navigationActions = navigationActions, houseHoldViewModel = houseHoldViewModel, foodItemViewModel = foodItemViewModel)
+          navigationActions = navigationActions,
+          houseHoldViewModel = houseHoldViewModel,
+          foodItemViewModel = foodItemViewModel)
     }
 
     // Verify that the loading indicator is displayed
@@ -107,7 +111,9 @@ class IndividualFoodItemScreenTest {
   fun testBackButtonNavigatesBack() = runTest {
     composeTestRule.setContent {
       IndividualFoodItemScreen(
-          navigationActions = navigationActions, houseHoldViewModel = houseHoldViewModel, foodItemViewModel = foodItemViewModel)
+          navigationActions = navigationActions,
+          houseHoldViewModel = houseHoldViewModel,
+          foodItemViewModel = foodItemViewModel)
     }
 
     // Perform click on the back button

--- a/app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt
@@ -80,7 +80,7 @@ class IndividualFoodItemScreenTest {
   fun individualFoodItemScreenDisplaysCorrectly() = runTest {
     composeTestRule.setContent {
       IndividualFoodItemScreen(
-          navigationActions = navigationActions, foodItemViewModel = foodItemViewModel)
+          navigationActions = navigationActions, houseHoldViewModel = houseHoldViewModel, foodItemViewModel = foodItemViewModel)
     }
 
     // Check if the screen displays the correct food item details
@@ -96,7 +96,7 @@ class IndividualFoodItemScreenTest {
 
     composeTestRule.setContent {
       IndividualFoodItemScreen(
-          navigationActions = navigationActions, foodItemViewModel = foodItemViewModel)
+          navigationActions = navigationActions, houseHoldViewModel = houseHoldViewModel, foodItemViewModel = foodItemViewModel)
     }
 
     // Verify that the loading indicator is displayed
@@ -107,7 +107,7 @@ class IndividualFoodItemScreenTest {
   fun testBackButtonNavigatesBack() = runTest {
     composeTestRule.setContent {
       IndividualFoodItemScreen(
-          navigationActions = navigationActions, foodItemViewModel = foodItemViewModel)
+          navigationActions = navigationActions, houseHoldViewModel = houseHoldViewModel, foodItemViewModel = foodItemViewModel)
     }
 
     // Perform click on the back button

--- a/app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt
+++ b/app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt
@@ -122,4 +122,23 @@ class IndividualFoodItemScreenTest {
     // Verify that the navigation action was triggered
     io.mockk.verify { navigationActions.goBack() }
   }
+
+  @Test
+  fun testDeleteFoodItem() = runTest {
+    composeTestRule.setContent {
+      IndividualFoodItemScreen(
+          navigationActions = navigationActions,
+          houseHoldViewModel = houseHoldViewModel,
+          foodItemViewModel = foodItemViewModel)
+    }
+
+    // Perform click on the delete icon
+    composeTestRule.onNodeWithTag("deleteFoodItem").performClick()
+
+    // Verify that the deleteFoodItem function was called
+    io.mockk.verify { houseHoldViewModel.deleteFoodItem(foodItem) }
+
+    // Verify that the navigation action was triggered
+    io.mockk.verify { navigationActions.goBack() }
+  }
 }

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -102,7 +102,7 @@ fun ShelfLifeApp() {
       }
       composable(Screen.INDIVIDUAL_FOOD_ITEM) {
         IndividualFoodItemScreen(
-            navigationActions = navigationActions, householdViewModel,  listFoodItemViewModel)
+            navigationActions = navigationActions, householdViewModel, listFoodItemViewModel)
       }
     }
     navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.SCANNER) {

--- a/app/src/main/java/com/android/shelfLife/MainActivity.kt
+++ b/app/src/main/java/com/android/shelfLife/MainActivity.kt
@@ -102,7 +102,7 @@ fun ShelfLifeApp() {
       }
       composable(Screen.INDIVIDUAL_FOOD_ITEM) {
         IndividualFoodItemScreen(
-            navigationActions = navigationActions, foodItemViewModel = listFoodItemViewModel)
+            navigationActions = navigationActions, householdViewModel,  listFoodItemViewModel)
       }
     }
     navigation(startDestination = Screen.PERMISSION_HANDLER, route = Route.SCANNER) {

--- a/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
@@ -181,6 +181,17 @@ class HouseholdViewModel(
     }
   }
 
+  fun deleteFoodItem(foodItem: FoodItem) {
+    val selectedHousehold = selectedHousehold.value
+    if (selectedHousehold != null) {
+      updateHousehold(
+        selectedHousehold.copy(
+          foodItems = selectedHousehold.foodItems.minus(foodItem)
+        )
+      )
+    }
+  }
+
   /**
    * Factory for creating a [HouseholdViewModel] with a constructor that takes a
    * [HouseHoldRepository] and a [ListFoodItemsViewModel].

--- a/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt
@@ -185,10 +185,7 @@ class HouseholdViewModel(
     val selectedHousehold = selectedHousehold.value
     if (selectedHousehold != null) {
       updateHousehold(
-        selectedHousehold.copy(
-          foodItems = selectedHousehold.foodItems.minus(foodItem)
-        )
-      )
+          selectedHousehold.copy(foodItems = selectedHousehold.foodItems.minus(foodItem)))
     }
   }
 

--- a/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
@@ -1,5 +1,6 @@
 package com.android.shelfLife.ui.overview
 
+import android.util.Log
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -7,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -30,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.android.shelfLife.model.foodItem.ListFoodItemsViewModel
+import com.android.shelfLife.model.household.HouseholdViewModel
 import com.android.shelfLife.ui.navigation.BottomNavigationMenu
 import com.android.shelfLife.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.shelfLife.ui.navigation.NavigationActions
@@ -41,6 +44,7 @@ import com.android.shelfLife.ui.utils.FoodItemDetails
 @Composable
 fun IndividualFoodItemScreen(
     navigationActions: NavigationActions,
+    houseHoldViewModel: HouseholdViewModel,
     foodItemViewModel: ListFoodItemsViewModel
 ) {
   val foodItem by foodItemViewModel.selectedFoodItem.collectAsState()
@@ -62,7 +66,21 @@ fun IndividualFoodItemScreen(
                   modifier = Modifier.testTag("IndividualTestScreenGoBack")) {
                     Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Go back Icon")
                   }
-            })
+            } ,
+            actions = {
+                IconButton(
+                    onClick = {
+                        foodItem?.let {
+                            houseHoldViewModel.deleteFoodItem(it)
+                            navigationActions.goBack()
+                        }
+                    },
+                    modifier = Modifier.testTag("deleteFoodItem")
+                ) {
+                    Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete Icon")
+                }
+            }
+        )
       },
       // Floating Action Button to edit the food item
       floatingActionButton = {

--- a/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt
@@ -1,6 +1,5 @@
 package com.android.shelfLife.ui.overview
 
-import android.util.Log
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -66,21 +65,19 @@ fun IndividualFoodItemScreen(
                   modifier = Modifier.testTag("IndividualTestScreenGoBack")) {
                     Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Go back Icon")
                   }
-            } ,
+            },
             actions = {
-                IconButton(
-                    onClick = {
-                        foodItem?.let {
-                            houseHoldViewModel.deleteFoodItem(it)
-                            navigationActions.goBack()
-                        }
-                    },
-                    modifier = Modifier.testTag("deleteFoodItem")
-                ) {
+              IconButton(
+                  onClick = {
+                    foodItem?.let {
+                      houseHoldViewModel.deleteFoodItem(it)
+                      navigationActions.goBack()
+                    }
+                  },
+                  modifier = Modifier.testTag("deleteFoodItem")) {
                     Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete Icon")
-                }
-            }
-        )
+                  }
+            })
       },
       // Floating Action Button to edit the food item
       floatingActionButton = {


### PR DESCRIPTION
This pull request includes several changes to the `IndividualFoodItemScreen` and its associated tests to integrate the `HouseholdViewModel` and add the functionality to delete a food item. The most important changes include adding the `HouseholdViewModel` to the relevant screens and tests, implementing the `deleteFoodItem` function in the `HouseholdViewModel`, and updating the UI to include a delete button. This is based on issue #187. An option to move and to delete food items from the overview screen will be added a future edition of the app.

### Integration of `HouseholdViewModel`:

* [`app/src/main/java/com/android/shelfLife/MainActivity.kt`](diffhunk://#diff-28e4a8bf43542ae1d1bf2c31241eaca6b63b1cf41a738d0bd6cc8c82e838b866L105-R105): Added `householdViewModel` to the `IndividualFoodItemScreen` composable.
* [`app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt`](diffhunk://#diff-af0abf1724c393382dbd691cd0b9b98ccf7ab6f2f71bfb71d33858eab52658deR34): Imported `HouseholdViewModel`, added it as a parameter to `IndividualFoodItemScreen`, and included it in the UI setup. [[1]](diffhunk://#diff-af0abf1724c393382dbd691cd0b9b98ccf7ab6f2f71bfb71d33858eab52658deR34) [[2]](diffhunk://#diff-af0abf1724c393382dbd691cd0b9b98ccf7ab6f2f71bfb71d33858eab52658deR46)

### Implementation of delete functionality:

* [`app/src/main/java/com/android/shelfLife/model/household/HouseholdViewModel.kt`](diffhunk://#diff-879a145676bb49a17bdb527a76bfdbcc6b1bba23fbb41cfcd4fc19fc5bfdb30dR184-R191): Implemented the `deleteFoodItem` function to remove a food item from the household.
* [`app/src/main/java/com/android/shelfLife/ui/overview/IndividualFoodItem.kt`](diffhunk://#diff-af0abf1724c393382dbd691cd0b9b98ccf7ab6f2f71bfb71d33858eab52658deR68-R79): Added a delete button to the screen, which calls the `deleteFoodItem` function and triggers a navigation action.

### Updates to tests:

* [`app/src/androidTest/java/com/android/shelflife/ui/EndToEndM2Test.kt`](diffhunk://#diff-85da5850c493d002526ba56f391796dbefcce4c8297208f50d119acbf7808959L170-R172): Added `householdViewModel` to the `IndividualFoodItemScreen` composable in the test setup.
* [`app/src/androidTest/java/com/android/shelflife/ui/overview/IndividualFoodItemTest.kt`](diffhunk://#diff-c5c5bd46a911a839c6203f1ed3ebbd4662451c1c3f8ab9f5490cd0fcee7a6bf2L83-R85): Updated tests to include `householdViewModel` and added a new test for the delete functionality. [[1]](diffhunk://#diff-c5c5bd46a911a839c6203f1ed3ebbd4662451c1c3f8ab9f5490cd0fcee7a6bf2L83-R85) [[2]](diffhunk://#diff-c5c5bd46a911a839c6203f1ed3ebbd4662451c1c3f8ab9f5490cd0fcee7a6bf2L99-R103) [[3]](diffhunk://#diff-c5c5bd46a911a839c6203f1ed3ebbd4662451c1c3f8ab9f5490cd0fcee7a6bf2L110-R116) [[4]](diffhunk://#diff-c5c5bd46a911a839c6203f1ed3ebbd4662451c1c3f8ab9f5490cd0fcee7a6bf2R125-R143)