### PR TITLE
fix: add viewModel to overviewScreen and move state to it

### DIFF
--- a/app/src/main/java/com/android/shelfLife/model/overview/OverviewScreenViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/model/overview/OverviewScreenViewModel.kt
@@ -1,0 +1,31 @@
+package com.android.shelfLife.model.overview
+
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class OverviewScreenViewModel() : ViewModel() {
+  private val _selectedFilters = MutableStateFlow<List<String>>(emptyList())
+  val selectedFilters = _selectedFilters.asStateFlow()
+
+  private val _drawerState = MutableStateFlow(DrawerState(DrawerValue.Closed))
+  val drawerState = _drawerState.asStateFlow()
+
+  val filters = listOf("Dairy", "Meat", "Fish", "Fruit", "Vegetables", "Bread", "Canned")
+
+  /**
+   * Toggles the filter on or off
+   *
+   * @param filter The filter to toggle
+   */
+  fun toggleFilter(filter: String) {
+    if (_selectedFilters.value.contains(filter)) {
+      _selectedFilters.update { it - filter }
+    } else {
+      _selectedFilters.update { it + filter }
+    }
+  }
+}

--- a/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt
@@ -132,7 +132,7 @@ fun HouseHoldCreationScreen(
                     if (isError) {
                       Text(
                           modifier = Modifier.fillMaxWidth(),
-                          text = "Household name already exists",
+                          text = "Household name already exists or is empty",
                           color = MaterialTheme.colorScheme.error)
                     }
                   },
@@ -232,9 +232,10 @@ fun HouseHoldCreationScreen(
                             ButtonDefaults.buttonColors(
                                 containerColor = MaterialTheme.colorScheme.secondaryContainer),
                         onClick = {
-                          if (householdViewModel.checkIfHouseholdNameExists(houseHoldName) &&
-                              (householdToEdit == null ||
-                                  houseHoldName != householdToEdit!!.name)) {
+                          if (houseHoldName.isBlank() ||
+                              householdViewModel.checkIfHouseholdNameExists(houseHoldName) &&
+                                  (householdToEdit == null ||
+                                      houseHoldName != householdToEdit!!.name)) {
                             isError = true
                           } else {
                             coroutineScope.launch {


### PR DESCRIPTION
## Changes
Added a viewModel for storing the state of the overviewScreen and added check to prevent submitting an empty name when creating or modifying a household.

### State Management Improvements:
* Added `OverviewScreenViewModel` class to manage filters and drawer state (`app/src/main/java/com/android/shelfLife/model/overview/OverviewScreenViewModel.kt`).
* Integrated `OverviewScreenViewModel` into `OverviewScreen` to handle selected filters and drawer state (`app/src/main/java/com/android/shelfLife/ui/overview/Overview.kt`). [[1]](diffhunk://#diff-e5ce7e1c8fda777b1bd5e30bf0fa324eadecbac4c236f0e683af02956480ad88L3-R27) [[2]](diffhunk://#diff-e5ce7e1c8fda777b1bd5e30bf0fa324eadecbac4c236f0e683af02956480ad88R49-L65) [[3]](diffhunk://#diff-e5ce7e1c8fda777b1bd5e30bf0fa324eadecbac4c236f0e683af02956480ad88L96-R96)

### Error Handling Improvements:
* Updated error message in `HouseHoldCreationScreen` to include empty household name check (`app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt`).
* Modified household name validation logic to check for blank names in `HouseHoldCreationScreen` (`app/src/main/java/com/android/shelfLife/ui/overview/HouseHoldCreationScreen.kt`).