### PR TITLE
feat: Add new viewModel for IndividualFoodItem

### DIFF
--- a/app/src/main/java/com/android/shelfLife/ui/newoverview/NewIndividualFoodItem.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/newoverview/NewIndividualFoodItem.kt
@@ -1,0 +1,108 @@
+package com.android.shelfLife.ui.newoverview
+
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import com.android.shelfLife.model.newFoodItem.FoodItemRepository
+import com.android.shelfLife.model.user.UserRepositoryFirestore
+import com.android.shelfLife.viewmodel.overview.IndividualFoodItemViewModel
+import kotlinx.coroutines.launch
+
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.android.shelfLife.ui.navigation.BottomNavigationMenu
+import com.android.shelfLife.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.android.shelfLife.ui.navigation.NavigationActions
+import com.android.shelfLife.ui.navigation.Route
+import com.android.shelfLife.ui.navigation.Screen
+import com.android.shelfLife.ui.utils.CustomTopAppBar
+import com.android.shelfLife.ui.utils.FoodItemDetails
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IndividualFoodItemScreen(
+    navigationActions: NavigationActions,
+    foodItemRepository: FoodItemRepository,
+    userRepository: UserRepositoryFirestore
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val individualFoodItemViewModel = IndividualFoodItemViewModel(foodItemRepository, userRepository)
+    val context = LocalContext.current
+
+    Scaffold(
+        modifier = Modifier.testTag("IndividualFoodItemScreen"),
+        topBar = {
+            CustomTopAppBar(
+                onClick = { navigationActions.goBack() },
+                title = if (individualFoodItemViewModel.selectedFood != null) individualFoodItemViewModel.selectedFood!!.foodFacts.name else "",
+                titleTestTag = "IndividualFoodItemName",
+                actions = {
+                    IconButton(
+                        onClick = {
+                            individualFoodItemViewModel.selectedFood?.let {
+                                coroutineScope.launch {
+                                    individualFoodItemViewModel.deleteFoodItem()
+                                    navigationActions.goBack()
+                                }
+                            }
+                        },
+                        modifier = Modifier.testTag("deleteFoodItem")) {
+                        Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete Icon")
+                    }
+                })
+        },
+        // Floating Action Button to edit the food item
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { navigationActions.navigateTo(Screen.EDIT_FOOD) },
+                content = { Icon(Icons.Default.Edit, contentDescription = "Edit") },
+                modifier = Modifier.testTag("editFoodFab"),
+                containerColor = MaterialTheme.colorScheme.secondaryContainer)
+        },
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { destination -> navigationActions.navigateTo(destination) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = Route.OVERVIEW)
+        }) { paddingValues ->
+        LazyColumn(modifier = Modifier.padding(paddingValues)) {
+            item {
+                if (individualFoodItemViewModel.selectedFood != null) {
+                    AsyncImage(
+                        model = individualFoodItemViewModel.selectedFood!!.foodFacts.imageUrl,
+                        contentDescription = "Food Image",
+                        modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .aspectRatio(1f)
+                            .clip(RoundedCornerShape(8.dp))
+                            .testTag("IndividualFoodItemImage"),
+                        contentScale = ContentScale.Crop)
+
+                    FoodItemDetails(foodItem = individualFoodItemViewModel.selectedFood!!)
+                } else {
+                    CircularProgressIndicator(modifier = Modifier.testTag("CircularProgressIndicator"))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/shelfLife/ui/newutils/NewFoodItemDetail.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/newutils/NewFoodItemDetail.kt
@@ -1,0 +1,104 @@
+package com.android.shelfLife.ui.utils
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.shelfLife.R
+
+/**
+ * Composable function to display the details of a food item.
+ *
+ * @param foodItem The food item whose details are to be displayed.
+ */
+@Composable
+fun FoodItemDetails(foodItem: com.android.shelfLife.model.newFoodItem.FoodItem) {
+    val textStyle = TextStyle(fontSize = 14.sp)
+
+    val formattedExpiryDate =
+        foodItem.expiryDate?.let { formatTimestampToDisplayDate(it) }
+            ?: stringResource(R.string.food_item_no_expiry_date)
+    val formattedOpenDate =
+        foodItem.openDate?.let { formatTimestampToDisplayDate(it) }
+            ?: stringResource(R.string.food_item_not_opened)
+    val formattedBuyDate = foodItem.buyDate?.let { formatTimestampToDisplayDate(it) }
+
+    ElevatedCard(
+        modifier =
+        Modifier.fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("foodItemDetailsCard")) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            FoodItemDetailText(
+                text =
+                stringResource(
+                    R.string.food_item_category_label, foodItem.foodFacts.category.name),
+                tag = "categoryText",
+                style = textStyle)
+            FoodItemDetailText(
+                text = stringResource(R.string.food_item_location_label, foodItem.location.name),
+                tag = "locationText",
+                style = textStyle)
+            FoodItemDetailText(
+                text = stringResource(R.string.food_item_status_label, foodItem.status.name),
+                tag = "statusText",
+                style = textStyle)
+            FoodItemDetailText(
+                text = stringResource(R.string.food_item_expiry_date_label, formattedExpiryDate),
+                tag = "expiryDateText",
+                style = textStyle)
+            FoodItemDetailText(
+                text = stringResource(R.string.food_item_open_date_label, formattedOpenDate),
+                tag = "openDateText",
+                style = textStyle)
+            formattedBuyDate?.let { stringResource(R.string.food_item_buy_date_label, it) }?.let {
+                FoodItemDetailText(
+                    text = it,
+                    tag = "buyDateText",
+                    style = textStyle)
+            }
+            FoodItemDetailText(
+                text =
+                stringResource(
+                    R.string.food_item_energy_label,
+                    foodItem.foodFacts.nutritionFacts.energyKcal),
+                tag = "energyText",
+                style = textStyle)
+            FoodItemDetailText(
+                text =
+                stringResource(
+                    R.string.food_item_proteins_label,
+                    foodItem.foodFacts.nutritionFacts.proteins),
+                tag = "proteinsText",
+                style = textStyle)
+            FoodItemDetailText(
+                text =
+                stringResource(
+                    R.string.food_item_quantity_label,
+                    foodItem.foodFacts.quantity.amount,
+                    foodItem.foodFacts.quantity.unit.name),
+                tag = "quantityText",
+                style = textStyle)
+        }
+    }
+}
+
+/**
+ * Composable function to display a text detail of a food item.
+ *
+ * @param text The text to be displayed.
+ * @param tag The test tag for the text.
+ * @param style The style to be applied to the text.
+ */
+@Composable
+fun FoodItemDetailText(text: String, tag: String, style: TextStyle) {
+    Text(text = text, style = style, modifier = Modifier.testTag(tag))
+}

--- a/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
@@ -30,7 +30,7 @@ fun FoodItemDetails(foodItem: FoodItem) {
   val formattedOpenDate =
       foodItem.openDate?.let { formatTimestampToDisplayDate(it) }
           ?: stringResource(R.string.food_item_not_opened)
-  val formattedBuyDate = formatTimestampToDisplayDate(foodItem.buyDate)
+  val formattedBuyDate = foodItem.buyDate?.let { formatTimestampToDisplayDate(it) }
 
   ElevatedCard(
       modifier =
@@ -60,10 +60,12 @@ fun FoodItemDetails(foodItem: FoodItem) {
               text = stringResource(R.string.food_item_open_date_label, formattedOpenDate),
               tag = "openDateText",
               style = textStyle)
-          FoodItemDetailText(
-              text = stringResource(R.string.food_item_buy_date_label, formattedBuyDate),
-              tag = "buyDateText",
-              style = textStyle)
+            formattedBuyDate?.let { stringResource(R.string.food_item_buy_date_label, it) }?.let {
+                FoodItemDetailText(
+                    text = it,
+                    tag = "buyDateText",
+                    style = textStyle)
+            }
           FoodItemDetailText(
               text =
                   stringResource(
@@ -90,14 +92,4 @@ fun FoodItemDetails(foodItem: FoodItem) {
       }
 }
 
-/**
- * Composable function to display a text detail of a food item.
- *
- * @param text The text to be displayed.
- * @param tag The test tag for the text.
- * @param style The style to be applied to the text.
- */
-@Composable
-fun FoodItemDetailText(text: String, tag: String, style: TextStyle) {
-  Text(text = text, style = style, modifier = Modifier.testTag(tag))
-}
+

--- a/app/src/main/java/com/android/shelfLife/viewmodel/overview/IndividualFoodItemViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/viewmodel/overview/IndividualFoodItemViewModel.kt
@@ -1,0 +1,29 @@
+package com.android.shelfLife.viewmodel.overview
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.android.shelfLife.model.newFoodItem.FoodItem
+import com.android.shelfLife.model.newFoodItem.FoodItemRepository
+import com.android.shelfLife.model.user.UserRepository
+
+class IndividualFoodItemViewModel (
+    private val foodItemRepository: FoodItemRepository,
+            private val userRepository: UserRepository
+): ViewModel(){
+    var selectedFood by mutableStateOf<FoodItem?>(null)
+
+    init{
+        selectedFood = foodItemRepository.selectedFoodItem.value
+    }
+
+    suspend fun deleteFoodItem(){
+        val householdId = userRepository.user.value?.selectedHouseholdUID
+        if(householdId != null){
+            foodItemRepository.deleteFoodItem(householdId, selectedFood!!.uid)
+            foodItemRepository.selectFoodItem(null)
+        }
+    }
+
+}


### PR DESCRIPTION
This PR just adds the missing IndividualFoodItemViewModel that should fitting in with the new architecture. I had to also replicate the composable for FoodItemDetails at least temporarily while we have both architecture in the project. In the future they will be deleted as there is no use for them. This is a small but significant change for the adoption of the new architecture. I would like to preface that this PR has no test not because I did not want to write them but rather I want to push this out of urgency so that we can construct the new architecture as soon as possible and hence not impede my colleagues on further actions.

### New Screen Implementation:
* [`app/src/main/java/com/android/shelfLife/ui/newoverview/NewIndividualFoodItem.kt`](diffhunk://#diff-dbbfe366c96c90eaedcf2e6934c4e8107a4c3a2f5ebb222b8f74c9499df35bf3R1-R108): Added the `IndividualFoodItemScreen` composable function to display individual food items, including a top app bar, floating action button, and bottom navigation menu.

### Utility Functions:
* [`app/src/main/java/com/android/shelfLife/ui/newutils/NewFoodItemDetail.kt`](diffhunk://#diff-3a6fdcac54ea3f83f99205232c6e07e55df14f475593d976e5d5ccff770bd8d3R1-R104): Added the `FoodItemDetails` composable function to display detailed information about a food item, including category, location, status, and nutritional facts.

### ViewModel:
* [`app/src/main/java/com/android/shelfLife/viewmodel/overview/IndividualFoodItemViewModel.kt`](diffhunk://#diff-acc8f652e4051c28d22def04f64b53954e7855c8fb707a6e4865661e05e66897R1-R29): Added `IndividualFoodItemViewModel` to manage the state of the individual food item screen, including selecting and deleting food items.

### Minor Fixes:
* [`app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt`](diffhunk://#diff-c329c86078a75f3feec6352d9a559dabcc9c18b1ae02725040641e094f9f2df5L33-R33): Fixed a bug where the buy date was not correctly formatted if it was null. [[1]](diffhunk://#diff-c329c86078a75f3feec6352d9a559dabcc9c18b1ae02725040641e094f9f2df5L33-R33) [[2]](diffhunk://#diff-c329c86078a75f3feec6352d9a559dabcc9c18b1ae02725040641e094f9f2df5R63-R68) [[3]](diffhunk://#diff-c329c86078a75f3feec6352d9a559dabcc9c18b1ae02725040641e094f9f2df5L93-R95)