### PR TITLE
Fix/335 fix food facts quantity

### DIFF
--- a/app/src/androidTest/java/com/android/shelfLife/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/android/shelfLife/ui/overview/OverviewTest.kt
@@ -145,7 +145,7 @@ class OverviewTest {
     composeTestRule.setContent { OverviewScreen(navigationActions = navigationActions) }
 
     // Check that the quantity text displays "1000ml"
-    composeTestRule.onNodeWithText("1000ml").assertIsDisplayed()
+    composeTestRule.onNodeWithText("1L").assertIsDisplayed()
   }
 
   // Test that "No Expiry Date" is displayed when expiry date is null

--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/FoodFacts.kt
@@ -41,7 +41,32 @@ data class Quantity(
     val unit: FoodUnit = FoodUnit.GRAM // Unit of the quantity
 ) {
   override fun toString(): String {
-    return "$amount ${unit.name.lowercase()}"
+    return when (unit) {
+      FoodUnit.GRAM -> {
+        if (amount >= 1000) {
+          val convertedAmount = amount / 1000
+          "${convertedAmount.toIntIfWhole()}kg"
+        } else {
+          "${amount.toIntIfWhole()}g"
+        }
+      }
+      FoodUnit.ML -> {
+        if (amount >= 1000) {
+          val convertedAmount = amount / 1000
+          "${convertedAmount.toIntIfWhole()}L"
+        } else {
+          "${amount.toIntIfWhole()}ml"
+        }
+      }
+      FoodUnit.COUNT -> {
+        "${amount.toInt()} in stock"
+      }
+    }
+  }
+
+  // Helper extension to display whole numbers without ".0"
+  private fun Double.toIntIfWhole(): String {
+    return if (this % 1.0 == 0.0) this.toInt().toString() else this.toString()
   }
 }
 

--- a/app/src/main/java/com/android/shelfLife/model/foodFacts/OpenFoodFactsRepository.kt
+++ b/app/src/main/java/com/android/shelfLife/model/foodFacts/OpenFoodFactsRepository.kt
@@ -205,15 +205,28 @@ class OpenFoodFactsRepository(
       val (amountString, _, _, unitString) = matchResult.destructured
 
       val amount = amountString.toDoubleOrNull() ?: 1.0 // Fallback to 1.0 if parsing fails
-      val unit = when (unitString) {
-        "g" -> FoodUnit.GRAM
-        "kg" -> FoodUnit.GRAM.also { return Quantity(amount * 1000, it) } // Convert kg -> g
-        "ml" -> FoodUnit.ML
-        "l" -> FoodUnit.ML.also { return Quantity(amount * 1000, it) } // Convert l -> ml
-        "dl" -> FoodUnit.ML.also { return Quantity(amount * 100, it) } // Convert dl -> ml
-        "cl" -> FoodUnit.ML.also { return Quantity(amount * 10, it) }  // Convert cl -> ml
-        else -> FoodUnit.COUNT // Default fallback
-      }
+      val unit =
+          when (unitString) {
+            "g" -> FoodUnit.GRAM
+            "kg" ->
+                FoodUnit.GRAM.also {
+                  return Quantity(amount * 1000, it)
+                } // Convert kg -> g
+            "ml" -> FoodUnit.ML
+            "l" ->
+                FoodUnit.ML.also {
+                  return Quantity(amount * 1000, it)
+                } // Convert l -> ml
+            "dl" ->
+                FoodUnit.ML.also {
+                  return Quantity(amount * 100, it)
+                } // Convert dl -> ml
+            "cl" ->
+                FoodUnit.ML.also {
+                  return Quantity(amount * 10, it)
+                } // Convert cl -> ml
+            else -> FoodUnit.COUNT // Default fallback
+          }
 
       Quantity(amount, unit)
     } else {
@@ -221,5 +234,4 @@ class OpenFoodFactsRepository(
       Quantity(1.0, FoodUnit.COUNT)
     }
   }
-
 }

--- a/app/src/main/java/com/android/shelfLife/ui/overview/FoodDisplayComponents.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/overview/FoodDisplayComponents.kt
@@ -152,12 +152,12 @@ fun FoodItemCard(
             Column(modifier = Modifier.weight(1f)) {
               Text(text = foodItem.foodFacts.name, fontSize = 16.sp, fontWeight = FontWeight.Bold)
               if (!isSelectedItemsList) {
-                Text(text = "${foodItem.foodFacts.quantity.amount.toInt()}$unit", fontSize = 12.sp)
+                Text(text = foodItem.foodFacts.quantity.toString(), fontSize = 12.sp)
               }
               Text(text = expiryDateMessage, fontSize = 12.sp)
             }
             if (isSelectedItemsList) {
-              Text(text = "${foodItem.foodFacts.quantity.amount.toInt()}$unit", fontSize = 12.sp)
+              Text(text = foodItem.foodFacts.quantity.toString(), fontSize = 12.sp)
             }
 
             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
@@ -78,10 +78,7 @@ fun FoodItemDetails(foodItem: com.android.shelfLife.model.foodItem.FoodItem) {
               style = textStyle)
           FoodItemDetailText(
               text =
-                  stringResource(
-                      R.string.food_item_quantity_label,
-                      foodItem.foodFacts.quantity.amount,
-                      foodItem.foodFacts.quantity.unit.name),
+                  stringResource(R.string.food_item_quantity_label).plus(" ").plus(foodItem.foodFacts.quantity),
               tag = "quantityText",
               style = textStyle)
         }

--- a/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
+++ b/app/src/main/java/com/android/shelfLife/ui/utils/FoodItemDetails.kt
@@ -78,7 +78,9 @@ fun FoodItemDetails(foodItem: com.android.shelfLife.model.foodItem.FoodItem) {
               style = textStyle)
           FoodItemDetailText(
               text =
-                  stringResource(R.string.food_item_quantity_label).plus(" ").plus(foodItem.foodFacts.quantity),
+                  stringResource(R.string.food_item_quantity_label)
+                      .plus(" ")
+                      .plus(foodItem.foodFacts.quantity),
               tag = "quantityText",
               style = textStyle)
         }

--- a/app/src/main/java/com/android/shelfLife/viewmodel/authentication/SignInViewModel.kt
+++ b/app/src/main/java/com/android/shelfLife/viewmodel/authentication/SignInViewModel.kt
@@ -24,12 +24,12 @@ import kotlinx.coroutines.tasks.await
 class SignInViewModel
 @Inject
 constructor(
-  private val firebaseAuth: FirebaseAuth,
-  private val userRepository: UserRepository,
-  private val householdRepository: HouseHoldRepository,
-  private val recipeRepository: RecipeRepository,
-  private val foodItemRepository: FoodItemRepository,
-  @ApplicationContext private val appContext: Context
+    private val firebaseAuth: FirebaseAuth,
+    private val userRepository: UserRepository,
+    private val householdRepository: HouseHoldRepository,
+    private val recipeRepository: RecipeRepository,
+    private val foodItemRepository: FoodItemRepository,
+    @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
   private val _signInState = MutableStateFlow<SignInState>(SignInState.Idle)
@@ -41,12 +41,12 @@ constructor(
   val bypassLogin = userRepository.bypassLogin
 
   private val authStateListener =
-    FirebaseAuth.AuthStateListener { auth ->
-      Log.d("SignInViewModel", "AuthStateListener triggered, user: ${auth.currentUser}")
-      if (auth.currentUser == null) {
-        _isUserLoggedIn.value = false
+      FirebaseAuth.AuthStateListener { auth ->
+        Log.d("SignInViewModel", "AuthStateListener triggered, user: ${auth.currentUser}")
+        if (auth.currentUser == null) {
+          _isUserLoggedIn.value = false
+        }
       }
-    }
 
   init {
     firebaseAuth.addAuthStateListener(authStateListener)
@@ -61,8 +61,8 @@ constructor(
   private suspend fun populateModelData(context: Context) {
     userRepository.initializeUserData(context)
     householdRepository.initializeHouseholds(
-      userRepository.user.value?.householdUIDs ?: emptyList(),
-      userRepository.user.value?.selectedHouseholdUID)
+        userRepository.user.value?.householdUIDs ?: emptyList(),
+        userRepository.user.value?.selectedHouseholdUID)
     userRepository.user.value?.selectedHouseholdUID?.let { foodItemRepository.getFoodItems(it) }
     userRepository.user.value?.let { recipeRepository.initializeRecipes(it.recipeUIDs, null) }
   }
@@ -94,12 +94,12 @@ constructor(
 
   fun signOutUser(context: Context, onSignOutComplete: () -> Unit) {
     val googleSignInClient =
-      GoogleSignIn.getClient(
-        context,
-        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-          .requestIdToken(context.getString(R.string.default_web_client_id))
-          .requestEmail()
-          .build())
+        GoogleSignIn.getClient(
+            context,
+            GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestIdToken(context.getString(R.string.default_web_client_id))
+                .requestEmail()
+                .build())
 
     googleSignInClient.signOut().addOnCompleteListener { task ->
       if (task.isSuccessful) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@
     <string name="food_item_buy_date_label">Buy Date: %1$s</string>
     <string name="food_item_energy_label">Energy: %1$d Kcal</string>
     <string name="food_item_proteins_label">Proteins: %1$s g</string>
-    <string name="food_item_quantity_label">Quantity: %1$s %2$s</string>
+    <string name="food_item_quantity_label">Quantity: </string>
 
     <string name="title_of_AddRecipeScreen">Add your own recipe</string>
     <string name="title_of_recipe">Recipe title</string>


### PR DESCRIPTION
# PR: Fix FoodFacts quantities

## Issue fixed
(previous issue): Scanned food items were  **always** being scanned and saved with a default **1g**

## Changes made
### Updated the `OpenFoodFactsRepository`
  - Now properly parses "ml", "g", "cl", "ml, "dl", "kg" correctly into the right `Quantity` data object (using regex)
  - Now Defaults to 1 count, which makes more sense than 1 gram

### Updated the `FoodDisplayComponent` and `IndividualFoodItem` Screens
  - Now properly show the Quantity
  - Now have proper unit switching (ml -> L etc.)